### PR TITLE
Adds an all artifact to the published libraries

### DIFF
--- a/publish.gradle
+++ b/publish.gradle
@@ -166,6 +166,25 @@ model {
             }
         })
 
+        def allCppTask
+        if (!project.hasProperty('jenkinsBuild')) {
+            allCppTask = project.tasks.create("wpiutilAllZip", Zip) {
+                description = 'Creates a zip with all Cpp artifacts'
+                classifier = 'all'
+                baseName = 'zipcppwpiutilwpiutil'
+                destinationDir = outputsFolder
+                duplicatesStrategy = 'exclude'
+
+                wpiutilTaskList.each { 
+                    it.outputs.files.each {
+                        from project.zipTree(it)
+                    }
+                    dependsOn it
+                }
+            }
+            project.build.dependsOn allCppTask
+        }
+
         publications {
             cpp(MavenPublication) {
                 wpiutilTaskList.each {
@@ -173,6 +192,10 @@ model {
                 }
                 artifact cppHeadersZip
                 artifact cppSourcesZip
+
+                if (!project.hasProperty('jenkinsBuild')) {
+                    artifact allCppTask
+                }
 
                 artifactId = "${baseArtifactId}-cpp"
                 groupId artifactGroupId


### PR DESCRIPTION
Better then the old desktop zips because it will include all artifacts
built, not just specifically the desktop ones. Also, the individual
artifacts are published as well so users can decide which artifacts they
specifically want, and can help decrease download sizes. The cpp plugin
will continue using the individual artifacts.