### PR TITLE
tcpsockets: Don't pull in platform-specific headers in headers.

### DIFF
--- a/src/main/native/cpp/tcpsockets/SocketError.cpp
+++ b/src/main/native/cpp/tcpsockets/SocketError.cpp
@@ -8,12 +8,22 @@
 #include "tcpsockets/SocketError.h"
 
 #ifdef _WIN32
+#include <WinSock2.h>
 #include <windows.h>
 #else
+#include <errno.h>
 #include <string.h>
 #endif
 
 namespace wpi {
+
+int SocketErrno() {
+#ifdef _WIN32
+  return WSAGetLastError();
+#else
+  return errno;
+#endif
+}
 
 std::string SocketStrerror(int code) {
 #ifdef _WIN32

--- a/src/main/native/include/tcpsockets/SocketError.h
+++ b/src/main/native/include/tcpsockets/SocketError.h
@@ -10,21 +10,9 @@
 
 #include <string>
 
-#ifdef _WIN32
-#include <WinSock2.h>
-#else
-#include <errno.h>
-#endif
-
 namespace wpi {
 
-static inline int SocketErrno() {
-#ifdef _WIN32
-  return WSAGetLastError();
-#else
-  return errno;
-#endif
-}
+int SocketErrno();
 
 std::string SocketStrerror(int code);
 

--- a/src/main/native/include/tcpsockets/TCPStream.h
+++ b/src/main/native/include/tcpsockets/TCPStream.h
@@ -27,12 +27,6 @@
 #include <cstddef>
 #include <string>
 
-#ifdef _WIN32
-#include <winsock2.h>
-#else
-#include <sys/socket.h>
-#endif
-
 #include "tcpsockets/NetworkStream.h"
 
 struct sockaddr_in;


### PR DESCRIPTION
This effectively pollutes the namespace for all users of these headers.
This is particularly an issue on Windows.