### PR TITLE
Makes an empty stringref have a valid Data pointer

### DIFF
--- a/src/main/native/include/llvm/StringRef.h
+++ b/src/main/native/include/llvm/StringRef.h
@@ -76,7 +76,9 @@ namespace llvm {
     /// @{
 
     /// Construct an empty string ref.
-    /*implicit*/ StringRef() : Data(nullptr), Length(0) {}
+    /*implicit*/ StringRef() : Data(""), Length(0) {
+        set_null_terminated(true);
+      }
 
     /// Construct a string ref from a cstring.
     /*implicit*/ StringRef(const char *Str)


### PR DESCRIPTION
Done by using the Length variable as data. When 0, is null terminated,
and 0 means the null termination flag is set. This is different from
past cases.