### PR TITLE
LLVM path: Don't follow symlinks.

### DIFF
--- a/src/main/native/cpp/llvm/Unix/Path.inc
+++ b/src/main/native/cpp/llvm/Unix/Path.inc
@@ -142,6 +142,8 @@ static std::error_code fillStatus(int StatRet, const struct stat &Status,
     Type = file_type::fifo_file;
   else if (S_ISSOCK(Status.st_mode))
     Type = file_type::socket_file;
+  else if (S_ISLNK(Status.st_mode))
+    Type = file_type::symlink_file;
 
   perms Perms = static_cast<perms>(Status.st_mode);
   Result =
@@ -157,7 +159,7 @@ std::error_code status(const Twine &Path, file_status &Result) {
   StringRef P = Path.toNullTerminatedStringRef(PathStorage);
 
   struct stat Status;
-  int StatRet = ::stat(P.begin(), &Status);
+  int StatRet = ::lstat(P.begin(), &Status);
   return fillStatus(StatRet, Status, Result);
 }
 


### PR DESCRIPTION
This causes issues in recursive_directory_iterator.