### PR TITLE
Make JxArrayRef less error-prone for jxArray.

### DIFF
--- a/src/main/native/include/support/jni_util.h
+++ b/src/main/native/include/support/jni_util.h
@@ -197,12 +197,15 @@ class JArrayRefBase : public JArrayRefInner<JArrayRefBase<T>, T> {
     this->m_elements = elements;
   }
 
-  JArrayRefBase(JNIEnv *env, jarray jarr) {
+  JArrayRefBase(JNIEnv *env, jarray jarr, size_t size) {
     this->m_env = env;
     this->m_jarr = jarr;
-    this->m_size = jarr ? env->GetArrayLength(jarr) : 0;
+    this->m_size = size;
     this->m_elements = nullptr;
   }
+
+  JArrayRefBase(JNIEnv *env, jarray jarr)
+      : JArrayRefBase(env, jarr, jarr ? env->GetArrayLength(jarr) : 0) {}
 
   JNIEnv *m_env;
   jarray m_jarr = nullptr;
@@ -226,6 +229,14 @@ class JArrayRefBase : public JArrayRefInner<JArrayRefBase<T>, T> {
         llvm::errs() << "JArrayRef was passed a null pointer at \n"            \
                      << GetJavaStackTrace(env);                                \
     }                                                                          \
+    J##F##ArrayRef(JNIEnv* env, T##Array jarr, int len)                        \
+        : detail::JArrayRefBase<T>(env, jarr, len) {                           \
+      if (jarr)                                                                \
+        m_elements = env->Get##F##ArrayElements(jarr, nullptr);                \
+      else                                                                     \
+        llvm::errs() << "JArrayRef was passed a null pointer at \n"            \
+                     << GetJavaStackTrace(env);                                \
+    }                                                                          \
     J##F##ArrayRef(JNIEnv* env, T##Array jarr)                                 \
         : detail::JArrayRefBase<T>(env, jarr) {                                \
       if (jarr)                                                                \
@@ -243,6 +254,15 @@ class JArrayRefBase : public JArrayRefInner<JArrayRefBase<T>, T> {
                                                                                \
   class CriticalJ##F##ArrayRef : public detail::JArrayRefBase<T> {             \
    public:                                                                     \
+    CriticalJ##F##ArrayRef(JNIEnv* env, T##Array jarr, int len)                \
+        : detail::JArrayRefBase<T>(env, jarr, len) {                           \
+      if (jarr)                                                                \
+        m_elements =                                                           \
+            static_cast<T*>(env->GetPrimitiveArrayCritical(jarr, nullptr));    \
+      else                                                                     \
+        llvm::errs() << "JArrayRef was passed a null pointer at \n"            \
+                     << GetJavaStackTrace(env);                                \
+    }                                                                          \
     CriticalJ##F##ArrayRef(JNIEnv* env, T##Array jarr)                         \
         : detail::JArrayRefBase<T>(env, jarr) {                                \
       if (jarr)                                                                \


### PR DESCRIPTION
Add a length-taking overload so that if a length happens to be provided for
a jarray, the direct byte buffer overload is not used.