### PR TITLE
WPI_Now(): return microseconds, and make backend replaceable.

### DIFF
--- a/src/main/native/include/support/timestamp.h
+++ b/src/main/native/include/support/timestamp.h
@@ -7,11 +7,33 @@
 #ifndef WPIUTIL_SUPPORT_TIMESTAMP_H_
 #define WPIUTIL_SUPPORT_TIMESTAMP_H_
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-unsigned long long WPI_Now(void);
+/**
+ * The default implementation used for Now().
+ * In general this is the time returned by the operating system.
+ * @return Time in microseconds.
+ */
+uint64_t WPI_NowDefault(void);
+
+/**
+ * Set the implementation used by WPI_Now().
+ * The implementation must return monotonic time in microseconds to maintain
+ * the contract of WPI_Now().
+ * @param func Function called by WPI_Now() to return the time.
+ */
+void WPI_SetNowImpl(uint64_t (*func)(void));
+
+/**
+ * Return a value representing the current time in microseconds.
+ * The epoch is not defined.
+ * @return Time in microseconds.
+ */
+uint64_t WPI_Now(void);
 
 #ifdef __cplusplus
 }
@@ -20,7 +42,27 @@ unsigned long long WPI_Now(void);
 #ifdef __cplusplus
 namespace wpi {
 
-unsigned long long Now();
+/**
+ * The default implementation used for Now().
+ * In general this is the time returned by the operating system.
+ * @return Time in microseconds.
+ */
+uint64_t NowDefault();
+
+/**
+ * Set the implementation used by Now().
+ * The implementation must return monotonic time in microseconds to maintain
+ * the contract of Now().
+ * @param func Function called by Now() to return the time.
+ */
+void SetNowImpl(uint64_t (*func)());
+
+/**
+ * Return a value representing the current time in microseconds.
+ * This is a monotonic clock with an undefined epoch.
+ * @return Time in microseconds.
+ */
+uint64_t Now();
 
 }  // namespace wpi
 #endif


### PR DESCRIPTION
 - Add function documentation.

 - Use uint64_t instead of unsigned long long