### PR TITLE
raw_istream: Don't forward declare Twine et al.

### DIFF
--- a/src/main/native/include/support/raw_istream.h
+++ b/src/main/native/include/support/raw_istream.h
@@ -12,12 +12,9 @@
 #include <cstddef>
 #include <system_error>
 
-namespace llvm {
-template <typename T>
-class SmallVectorImpl;
-class StringRef;
-class Twine;
-}
+#include "llvm/SmallVector.h"
+#include "llvm/StringRef.h"
+#include "llvm/Twine.h"
 
 namespace wpi {
 


### PR DESCRIPTION
It breaks existing users who use StringRef.