### PR TITLE
Rename llvm namespace to wpi_llvm

### DIFF
--- a/src/dev/native/cpp/main.cpp
+++ b/src/dev/native/cpp/main.cpp
@@ -12,6 +12,6 @@
 #include "support/hostname.h"
 
 int main() {
-  llvm::StringRef v1("Hello");
+  wpi_llvm::StringRef v1("Hello");
   std::cout << v1.lower() << std::endl;
 }

--- a/src/main/native/cpp/llvm/ConvertUTFWrapper.cpp
+++ b/src/main/native/cpp/llvm/ConvertUTFWrapper.cpp
@@ -11,7 +11,7 @@
 #include <string>
 #include <vector>
 
-namespace llvm {
+namespace wpi_llvm {
 
 bool ConvertCodePointToUTF8(unsigned Source, char *&ResultPtr) {
   const UTF32 *SourceStart = &Source;
@@ -118,5 +118,5 @@ bool convertUTF8ToUTF16String(StringRef SrcUTF8,
   return true;
 }
 
-} // end namespace llvm
+} // end namespace wpi_llvm
 

--- a/src/main/native/cpp/llvm/ErrorHandling.cpp
+++ b/src/main/native/cpp/llvm/ErrorHandling.cpp
@@ -24,7 +24,7 @@
   case x:                                                                      \
     return std::make_error_code(std::errc::y)
 
-std::error_code llvm::mapWindowsError(unsigned EV) {
+std::error_code wpi_llvm::mapWindowsError(unsigned EV) {
   switch (EV) {
     MAP_ERR_TO_COND(ERROR_ACCESS_DENIED, permission_denied);
     MAP_ERR_TO_COND(ERROR_ALREADY_EXISTS, file_exists);

--- a/src/main/native/cpp/llvm/Hashing.cpp
+++ b/src/main/native/cpp/llvm/Hashing.cpp
@@ -15,15 +15,15 @@
 
 #include "llvm/Hashing.h"
 
-using namespace llvm;
+using namespace wpi_llvm;
 
 // Provide a definition and static initializer for the fixed seed. This
 // initializer should always be zero to ensure its value can never appear to be
 // non-zero, even during dynamic initialization.
-size_t llvm::hashing::detail::fixed_seed_override = 0;
+size_t wpi_llvm::hashing::detail::fixed_seed_override = 0;
 
 // Implement the function for forced setting of the fixed seed.
 // FIXME: Use atomic operations here so that there is no data race.
-void llvm::set_fixed_execution_hash_seed(size_t fixed_value) {
+void wpi_llvm::set_fixed_execution_hash_seed(size_t fixed_value) {
   hashing::detail::fixed_seed_override = fixed_value;
 }

--- a/src/main/native/cpp/llvm/Path.cpp
+++ b/src/main/native/cpp/llvm/Path.cpp
@@ -25,11 +25,11 @@
 #include "llvm/FileSystem.h"
 #include "llvm/SmallString.h"
 
-using namespace llvm;
+using namespace wpi_llvm;
 
 namespace {
-  using llvm::StringRef;
-  using llvm::sys::path::is_separator;
+  using wpi_llvm::StringRef;
+  using wpi_llvm::sys::path::is_separator;
 
 #ifdef _WIN32
   const char *separators = "\\/";
@@ -148,7 +148,7 @@ namespace {
   }
 } // end unnamed namespace
 
-namespace llvm {
+namespace wpi_llvm {
 namespace sys  {
 namespace path {
 
@@ -626,7 +626,7 @@ static SmallString<256> remove_dots(StringRef path, bool remove_dot_dot) {
 
   // Skip the root path, then look for traversal in the components.
   StringRef rel = path::relative_path(path);
-  for (StringRef C : llvm::make_range(path::begin(rel), path::end(rel))) {
+  for (StringRef C : wpi_llvm::make_range(path::begin(rel), path::end(rel))) {
     if (C == ".")
       continue;
     if (remove_dot_dot) {
@@ -795,7 +795,7 @@ std::error_code directory_entry::status(file_status &result) const {
 
 } // end namespace fs
 } // end namespace sys
-} // end namespace llvm
+} // end namespace wpi_llvm
 
 // Include the truly platform-specific parts.
 #ifdef _WIN32
@@ -804,7 +804,7 @@ std::error_code directory_entry::status(file_status &result) const {
 #include "Unix/Path.inc"
 #endif
 
-namespace llvm {
+namespace wpi_llvm {
 namespace sys {
 namespace path {
 
@@ -819,4 +819,4 @@ bool user_cache_directory(SmallVectorImpl<char> &Result, const Twine &Path1,
 
 } // end namespace path
 } // end namsspace sys
-} // end namespace llvm
+} // end namespace wpi_llvm

--- a/src/main/native/cpp/llvm/SmallPtrSet.cpp
+++ b/src/main/native/cpp/llvm/SmallPtrSet.cpp
@@ -18,7 +18,7 @@
 #include <algorithm>
 #include <cstdlib>
 
-using namespace llvm;
+using namespace wpi_llvm;
 
 void SmallPtrSetImplBase::shrink_and_clear() {
   assert(!isSmall() && "Can't shrink a small set!");

--- a/src/main/native/cpp/llvm/SmallVector.cpp
+++ b/src/main/native/cpp/llvm/SmallVector.cpp
@@ -12,7 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/SmallVector.h"
-using namespace llvm;
+using namespace wpi_llvm;
 
 /// grow_pod - This is an implementation of the grow() method which only works
 /// on POD-like datatypes and is out of line to reduce code duplication.

--- a/src/main/native/cpp/llvm/StringExtras.cpp
+++ b/src/main/native/cpp/llvm/StringExtras.cpp
@@ -13,12 +13,12 @@
 
 #include "llvm/StringExtras.h"
 #include "llvm/SmallVector.h"
-using namespace llvm;
+using namespace wpi_llvm;
 
 /// StrInStrNoCase - Portable version of strcasestr.  Locates the first
 /// occurrence of string 's1' in string 's2', ignoring case.  Returns
 /// the offset of s2 in s1 or npos if s2 cannot be found.
-StringRef::size_type llvm::StrInStrNoCase(StringRef s1, StringRef s2) {
+StringRef::size_type wpi_llvm::StrInStrNoCase(StringRef s1, StringRef s2) {
   size_t N = s2.size(), M = s1.size();
   if (N > M)
     return StringRef::npos;
@@ -34,7 +34,7 @@ StringRef::size_type llvm::StrInStrNoCase(StringRef s1, StringRef s2) {
 /// there are no tokens in the source string, an empty string is returned.
 /// The function returns a pair containing the extracted token and the
 /// remaining tail string.
-std::pair<StringRef, StringRef> llvm::getToken(StringRef Source,
+std::pair<StringRef, StringRef> wpi_llvm::getToken(StringRef Source,
                                                StringRef Delimiters) {
   // Figure out where the token starts.
   StringRef::size_type Start = Source.find_first_not_of(Delimiters);
@@ -47,7 +47,7 @@ std::pair<StringRef, StringRef> llvm::getToken(StringRef Source,
 
 /// SplitString - Split up the specified string according to the specified
 /// delimiters, appending the result fragments to the output list.
-void llvm::SplitString(StringRef Source,
+void wpi_llvm::SplitString(StringRef Source,
                        SmallVectorImpl<StringRef> &OutFragments,
                        StringRef Delimiters) {
   std::pair<StringRef, StringRef> S = getToken(Source, Delimiters);

--- a/src/main/native/cpp/llvm/StringMap.cpp
+++ b/src/main/native/cpp/llvm/StringMap.cpp
@@ -16,7 +16,7 @@
 #include "llvm/StringExtras.h"
 #include "llvm/Compiler.h"
 #include <cassert>
-using namespace llvm;
+using namespace wpi_llvm;
 
 /// Returns the number of buckets to allocate to ensure that the DenseMap can
 /// accommodate \p NumEntries without need to grow().

--- a/src/main/native/cpp/llvm/StringRef.cpp
+++ b/src/main/native/cpp/llvm/StringRef.cpp
@@ -13,7 +13,7 @@
 #include <bitset>
 #include <climits>
 
-using namespace llvm;
+using namespace wpi_llvm;
 
 // MSVC emits references to this into the translation units which reference it.
 #ifndef _MSC_VER
@@ -120,7 +120,7 @@ std::string StringRef::upper() const {
   return Result;
 }
 
-const char *StringRef::c_str(llvm::SmallVectorImpl<char>& buf) const {
+const char *StringRef::c_str(wpi_llvm::SmallVectorImpl<char>& buf) const {
   if (is_null_terminated()) {
     // If null terminated, return data directly
     return data();
@@ -379,7 +379,7 @@ static unsigned GetAutoSenseRadix(StringRef &Str) {
 
 /// GetAsUnsignedInteger - Workhorse method that converts a integer character
 /// sequence of radix up to 36 to an unsigned long long value.
-bool llvm::getAsUnsignedInteger(StringRef Str, unsigned Radix,
+bool wpi_llvm::getAsUnsignedInteger(StringRef Str, unsigned Radix,
                                 unsigned long long &Result) {
   // Autosense radix if not specified.
   if (Radix == 0)
@@ -420,7 +420,7 @@ bool llvm::getAsUnsignedInteger(StringRef Str, unsigned Radix,
   return false;
 }
 
-bool llvm::getAsSignedInteger(StringRef Str, unsigned Radix,
+bool wpi_llvm::getAsSignedInteger(StringRef Str, unsigned Radix,
                               long long &Result) {
   unsigned long long ULLVal;
 
@@ -447,6 +447,6 @@ bool llvm::getAsSignedInteger(StringRef Str, unsigned Radix,
 }
 
 // Implementation of StringRef hashing.
-hash_code llvm::hash_value(StringRef S) {
+hash_code wpi_llvm::hash_value(StringRef S) {
   return hash_combine_range(S.begin(), S.end());
 }

--- a/src/main/native/cpp/llvm/Twine.cpp
+++ b/src/main/native/cpp/llvm/Twine.cpp
@@ -10,7 +10,7 @@
 #include "llvm/Twine.h"
 #include "llvm/SmallString.h"
 #include "llvm/raw_ostream.h"
-using namespace llvm;
+using namespace wpi_llvm;
 
 std::string Twine::str() const {
   // If we're storing only a std::string, just return it.

--- a/src/main/native/cpp/llvm/Unix/Path.inc
+++ b/src/main/native/cpp/llvm/Unix/Path.inc
@@ -28,7 +28,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-namespace llvm {
+namespace wpi_llvm {
 namespace sys  {
 namespace fs {
 UniqueID file_status::getUniqueID() const {
@@ -39,10 +39,10 @@ std::error_code current_path(SmallVectorImpl<char> &result) {
   result.clear();
 
   const char *pwd = ::getenv("PWD");
-  llvm::sys::fs::file_status PWDStatus, DotStatus;
-  if (pwd && llvm::sys::path::is_absolute(pwd) &&
-      !llvm::sys::fs::status(pwd, PWDStatus) &&
-      !llvm::sys::fs::status(".", DotStatus) &&
+  wpi_llvm::sys::fs::file_status PWDStatus, DotStatus;
+  if (pwd && wpi_llvm::sys::path::is_absolute(pwd) &&
+      !wpi_llvm::sys::fs::status(pwd, PWDStatus) &&
+      !wpi_llvm::sys::fs::status(".", DotStatus) &&
       PWDStatus.getUniqueID() == DotStatus.getUniqueID()) {
     result.append(pwd, pwd + strlen(pwd));
     return std::error_code();
@@ -387,4 +387,4 @@ void system_temp_directory(bool ErasedOnReboot, SmallVectorImpl<char> &Result) {
 
 } // end namespace path
 } // end namespace sys
-} // end namespace llvm
+} // end namespace wpi_llvm

--- a/src/main/native/cpp/llvm/Windows/Path.inc
+++ b/src/main/native/cpp/llvm/Windows/Path.inc
@@ -35,11 +35,11 @@
 # pragma comment(lib, "ole32.lib")
 #endif
 
-using namespace llvm;
+using namespace wpi_llvm;
 
-using llvm::sys::windows::UTF8ToUTF16;
-using llvm::sys::windows::UTF16ToUTF8;
-using llvm::sys::path::widenPath;
+using wpi_llvm::sys::windows::UTF8ToUTF16;
+using wpi_llvm::sys::windows::UTF16ToUTF8;
+using wpi_llvm::sys::path::widenPath;
 
 static bool is_separator(const wchar_t value) {
   switch (value) {
@@ -51,7 +51,7 @@ static bool is_separator(const wchar_t value) {
   }
 }
 
-namespace llvm {
+namespace wpi_llvm {
 namespace sys  {
 namespace path {
 
@@ -69,7 +69,7 @@ std::error_code widenPath(const Twine &Path8,
 
   // If we made this path absolute, how much longer would it get?
   size_t CurPathLen;
-  if (llvm::sys::path::is_absolute(Twine(Path8Str)))
+  if (wpi_llvm::sys::path::is_absolute(Twine(Path8Str)))
     CurPathLen = 0; // No contribution from current_path needed.
   else {
     CurPathLen = ::GetCurrentDirectoryW(0, NULL);
@@ -83,7 +83,7 @@ std::error_code widenPath(const Twine &Path8,
     SmallString<2*MAX_PATH> FullPath("\\\\?\\");
     if (CurPathLen) {
       SmallString<80> CurPath;
-      if (std::error_code EC = llvm::sys::fs::current_path(CurPath))
+      if (std::error_code EC = wpi_llvm::sys::fs::current_path(CurPath))
         return EC;
       FullPath.append(CurPath);
     }
@@ -91,15 +91,15 @@ std::error_code widenPath(const Twine &Path8,
     // the \\?\ prefix is documented to treat them as real components).
     // The iterators don't report separators and append() always attaches
     // preferred_separator so we don't need to call native() on the result.
-    for (llvm::sys::path::const_iterator I = llvm::sys::path::begin(Path8Str),
-                                         E = llvm::sys::path::end(Path8Str);
+    for (wpi_llvm::sys::path::const_iterator I = wpi_llvm::sys::path::begin(Path8Str),
+                                         E = wpi_llvm::sys::path::end(Path8Str);
                                          I != E; ++I) {
       if (I->size() == 1 && *I == ".")
         continue;
       if (I->size() == 2 && *I == "..")
-        llvm::sys::path::remove_filename(FullPath);
+        wpi_llvm::sys::path::remove_filename(FullPath);
       else
-        llvm::sys::path::append(FullPath, *I);
+        wpi_llvm::sys::path::append(FullPath, *I);
     }
     return UTF8ToUTF16(FullPath, Path16);
   }
@@ -577,8 +577,8 @@ void system_temp_directory(bool ErasedOnReboot, SmallVectorImpl<char> &Result) {
 } // end namespace path
 
 namespace windows {
-std::error_code UTF8ToUTF16(llvm::StringRef utf8,
-                            llvm::SmallVectorImpl<wchar_t> &utf16) {
+std::error_code UTF8ToUTF16(wpi_llvm::StringRef utf8,
+                            wpi_llvm::SmallVectorImpl<wchar_t> &utf16) {
   if (!utf8.empty()) {
     int len = ::MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, utf8.begin(),
                                     utf8.size(), utf16.begin(), 0);
@@ -606,7 +606,7 @@ std::error_code UTF8ToUTF16(llvm::StringRef utf8,
 static
 std::error_code UTF16ToCodePage(unsigned codepage, const wchar_t *utf16,
                                 size_t utf16_len,
-                                llvm::SmallVectorImpl<char> &utf8) {
+                                wpi_llvm::SmallVectorImpl<char> &utf8) {
   if (utf16_len) {
     // Get length.
     int len = ::WideCharToMultiByte(codepage, 0, utf16, utf16_len, utf8.begin(),
@@ -634,15 +634,15 @@ std::error_code UTF16ToCodePage(unsigned codepage, const wchar_t *utf16,
 }
 
 std::error_code UTF16ToUTF8(const wchar_t *utf16, size_t utf16_len,
-                            llvm::SmallVectorImpl<char> &utf8) {
+                            wpi_llvm::SmallVectorImpl<char> &utf8) {
   return UTF16ToCodePage(CP_UTF8, utf16, utf16_len, utf8);
 }
 
 std::error_code UTF16ToCurCP(const wchar_t *utf16, size_t utf16_len,
-                             llvm::SmallVectorImpl<char> &utf8) {
+                             wpi_llvm::SmallVectorImpl<char> &utf8) {
   return UTF16ToCodePage(CP_ACP, utf16, utf16_len, utf8);
 }
 
 } // end namespace windows
 } // end namespace sys
-} // end namespace llvm
+} // end namespace wpi_llvm

--- a/src/main/native/cpp/llvm/Windows/WindowsSupport.h
+++ b/src/main/native/cpp/llvm/Windows/WindowsSupport.h
@@ -79,7 +79,7 @@ inline bool MakeErrMsg(std::string *ErrMsg, const std::string &prefix) {
     *ErrMsg = prefix + ": " + buffer;
   else
     *ErrMsg = prefix + ": Unknown error";
-  *ErrMsg += " (0x" + llvm::utohexstr(LastError) + ")";
+  *ErrMsg += " (0x" + wpi_llvm::utohexstr(LastError) + ")";
 
   LocalFree(buffer);
   return R != 0;
@@ -179,7 +179,7 @@ typedef ScopedHandle<RegTraits>          ScopedRegHandle;
 typedef ScopedHandle<FindHandleTraits>   ScopedFindHandle;
 typedef ScopedHandle<JobHandleTraits>    ScopedJobHandle;
 
-namespace llvm {
+namespace wpi_llvm {
 template <class T>
 class SmallVectorImpl;
 
@@ -206,6 +206,6 @@ std::error_code UTF16ToCurCP(const wchar_t *utf16, size_t utf16_len,
                              SmallVectorImpl<char> &utf8);
 } // end namespace windows
 } // end namespace sys
-} // end namespace llvm.
+} // end namespace wpi_llvm.
 
 #endif

--- a/src/main/native/cpp/llvm/raw_os_ostream.cpp
+++ b/src/main/native/cpp/llvm/raw_os_ostream.cpp
@@ -13,7 +13,7 @@
 
 #include "llvm/raw_os_ostream.h"
 #include <ostream>
-using namespace llvm;
+using namespace wpi_llvm;
 
 //===----------------------------------------------------------------------===//
 //  raw_os_ostream

--- a/src/main/native/cpp/llvm/raw_ostream.cpp
+++ b/src/main/native/cpp/llvm/raw_ostream.cpp
@@ -53,7 +53,7 @@
 #include "Windows/WindowsSupport.h"
 #endif
 
-using namespace llvm;
+using namespace wpi_llvm;
 
 raw_ostream::~raw_ostream() {
   // raw_ostream's subclasses should take care to flush the buffer
@@ -657,7 +657,7 @@ size_t raw_fd_ostream::preferred_buffer_size() const {
 
 /// outs() - This returns a reference to a raw_ostream for standard output.
 /// Use it like: outs() << "foo" << "bar";
-raw_ostream &llvm::outs() {
+raw_ostream &wpi_llvm::outs() {
   // Set buffer settings to model stdout behavior.  Delete the file descriptor
   // when the program exits, forcing error detection.  This means that if you
   // ever call outs(), you can't open another raw_fd_ostream on stdout, as we'll
@@ -670,14 +670,14 @@ raw_ostream &llvm::outs() {
 
 /// errs() - This returns a reference to a raw_ostream for standard error.
 /// Use it like: errs() << "foo" << "bar";
-raw_ostream &llvm::errs() {
+raw_ostream &wpi_llvm::errs() {
   // Set standard error to be unbuffered by default.
   static raw_fd_ostream S(STDERR_FILENO, false, true);
   return S;
 }
 
 /// nulls() - This returns a reference to a raw_ostream which discards output.
-raw_ostream &llvm::nulls() {
+raw_ostream &wpi_llvm::nulls() {
   static raw_null_ostream S;
   return S;
 }

--- a/src/main/native/cpp/support/Base64.cpp
+++ b/src/main/native/cpp/support/Base64.cpp
@@ -80,7 +80,7 @@ static const unsigned char pr2six[256] = {
     64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
     64, 64, 64, 64, 64, 64, 64, 64, 64};
 
-size_t Base64Decode(llvm::raw_ostream& os, llvm::StringRef encoded) {
+size_t Base64Decode(wpi_llvm::raw_ostream& os, wpi_llvm::StringRef encoded) {
   const unsigned char* end = encoded.bytes_begin();
   while (pr2six[*end] <= 63 && end != encoded.bytes_end()) ++end;
   size_t nprbytes = end - encoded.bytes_begin();
@@ -107,18 +107,18 @@ size_t Base64Decode(llvm::raw_ostream& os, llvm::StringRef encoded) {
   return (end - encoded.bytes_begin()) + ((4 - nprbytes) & 3);
 }
 
-size_t Base64Decode(llvm::StringRef encoded, std::string* plain) {
+size_t Base64Decode(wpi_llvm::StringRef encoded, std::string* plain) {
   plain->resize(0);
-  llvm::raw_string_ostream os(*plain);
+  wpi_llvm::raw_string_ostream os(*plain);
   size_t rv = Base64Decode(os, encoded);
   os.flush();
   return rv;
 }
 
-llvm::StringRef Base64Decode(llvm::StringRef encoded, size_t* num_read,
-                             llvm::SmallVectorImpl<char>& buf) {
+wpi_llvm::StringRef Base64Decode(wpi_llvm::StringRef encoded, size_t* num_read,
+                             wpi_llvm::SmallVectorImpl<char>& buf) {
   buf.clear();
-  llvm::raw_svector_ostream os(buf);
+  wpi_llvm::raw_svector_ostream os(buf);
   *num_read = Base64Decode(os, encoded);
   return os.str();
 }
@@ -126,7 +126,7 @@ llvm::StringRef Base64Decode(llvm::StringRef encoded, size_t* num_read,
 static const char basis_64[] =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
-void Base64Encode(llvm::raw_ostream& os, llvm::StringRef plain) {
+void Base64Encode(wpi_llvm::raw_ostream& os, wpi_llvm::StringRef plain) {
   if (plain.empty()) return;
   size_t len = plain.size();
 
@@ -153,17 +153,17 @@ void Base64Encode(llvm::raw_ostream& os, llvm::StringRef plain) {
   }
 }
 
-void Base64Encode(llvm::StringRef plain, std::string* encoded) {
+void Base64Encode(wpi_llvm::StringRef plain, std::string* encoded) {
   encoded->resize(0);
-  llvm::raw_string_ostream os(*encoded);
+  wpi_llvm::raw_string_ostream os(*encoded);
   Base64Encode(os, plain);
   os.flush();
 }
 
-llvm::StringRef Base64Encode(llvm::StringRef plain,
-                             llvm::SmallVectorImpl<char>& buf) {
+wpi_llvm::StringRef Base64Encode(wpi_llvm::StringRef plain,
+                             wpi_llvm::SmallVectorImpl<char>& buf) {
   buf.clear();
-  llvm::raw_svector_ostream os(buf);
+  wpi_llvm::raw_svector_ostream os(buf);
   Base64Encode(os, plain);
   return os.str();
 }

--- a/src/main/native/cpp/support/HttpUtil.cpp
+++ b/src/main/native/cpp/support/HttpUtil.cpp
@@ -17,10 +17,10 @@
 
 namespace wpi {
 
-llvm::StringRef UnescapeURI(const llvm::Twine& str,
-                            llvm::SmallVectorImpl<char>& buf, bool* error) {
-  llvm::SmallString<128> strBuf;
-  llvm::StringRef strStr = str.toStringRef(strBuf);
+wpi_llvm::StringRef UnescapeURI(const wpi_llvm::Twine& str,
+                            wpi_llvm::SmallVectorImpl<char>& buf, bool* error) {
+  wpi_llvm::SmallString<128> strBuf;
+  wpi_llvm::StringRef strStr = str.toStringRef(strBuf);
   buf.clear();
   for (auto i = strStr.begin(), end = strStr.end(); i != end; ++i) {
     // pass non-escaped characters to output
@@ -36,33 +36,33 @@ llvm::StringRef UnescapeURI(const llvm::Twine& str,
     // are there enough characters left?
     if (i + 2 >= end) {
       *error = true;
-      return llvm::StringRef{};
+      return wpi_llvm::StringRef{};
     }
 
     // replace %xx with the corresponding character
-    unsigned val1 = llvm::hexDigitValue(*++i);
+    unsigned val1 = wpi_llvm::hexDigitValue(*++i);
     if (val1 == -1U) {
       *error = true;
-      return llvm::StringRef{};
+      return wpi_llvm::StringRef{};
     }
-    unsigned val2 = llvm::hexDigitValue(*++i);
+    unsigned val2 = wpi_llvm::hexDigitValue(*++i);
     if (val2 == -1U) {
       *error = true;
-      return llvm::StringRef{};
+      return wpi_llvm::StringRef{};
     }
     buf.push_back((val1 << 4) | val2);
   }
 
   *error = false;
-  return llvm::StringRef{buf.data(), buf.size()};
+  return wpi_llvm::StringRef{buf.data(), buf.size()};
 }
 
-llvm::StringRef EscapeURI(const llvm::Twine& str,
-                          llvm::SmallVectorImpl<char>& buf, bool spacePlus) {
+wpi_llvm::StringRef EscapeURI(const wpi_llvm::Twine& str,
+                          wpi_llvm::SmallVectorImpl<char>& buf, bool spacePlus) {
   static const char* const hexLut = "0123456789ABCDEF";
 
-  llvm::SmallString<128> strBuf;
-  llvm::StringRef strStr = str.toStringRef(strBuf);
+  wpi_llvm::SmallString<128> strBuf;
+  wpi_llvm::StringRef strStr = str.toStringRef(strBuf);
   buf.clear();
   for (auto i = strStr.begin(), end = strStr.end(); i != end; ++i) {
     // pass unreserved characters to output
@@ -83,19 +83,19 @@ llvm::StringRef EscapeURI(const llvm::Twine& str,
     buf.push_back(hexLut[(*i) & 0x0f]);
   }
 
-  return llvm::StringRef{buf.data(), buf.size()};
+  return wpi_llvm::StringRef{buf.data(), buf.size()};
 }
 
-bool ParseHttpHeaders(raw_istream& is, llvm::SmallVectorImpl<char>* contentType,
-                      llvm::SmallVectorImpl<char>* contentLength) {
+bool ParseHttpHeaders(raw_istream& is, wpi_llvm::SmallVectorImpl<char>* contentType,
+                      wpi_llvm::SmallVectorImpl<char>* contentLength) {
   if (contentType) contentType->clear();
   if (contentLength) contentLength->clear();
 
   bool inContentType = false;
   bool inContentLength = false;
-  llvm::SmallString<64> lineBuf;
+  wpi_llvm::SmallString<64> lineBuf;
   for (;;) {
-    llvm::StringRef line = is.getline(lineBuf, 1024).rtrim();
+    wpi_llvm::StringRef line = is.getline(lineBuf, 1024).rtrim();
     if (is.has_error()) return false;
     if (line.empty()) return true;  // empty line signals end of headers
 
@@ -103,7 +103,7 @@ bool ParseHttpHeaders(raw_istream& is, llvm::SmallVectorImpl<char>* contentType,
     if (!std::isspace(line[0])) {
       inContentType = false;
       inContentLength = false;
-      llvm::StringRef field;
+      wpi_llvm::StringRef field;
       std::tie(field, line) = line.split(':');
       field = field.rtrim();
       if (field == "Content-Type")
@@ -125,9 +125,9 @@ bool ParseHttpHeaders(raw_istream& is, llvm::SmallVectorImpl<char>* contentType,
   }
 }
 
-bool FindMultipartBoundary(raw_istream& is, llvm::StringRef boundary,
+bool FindMultipartBoundary(raw_istream& is, wpi_llvm::StringRef boundary,
                            std::string* saveBuf) {
-  llvm::SmallString<64> searchBuf;
+  wpi_llvm::SmallString<64> searchBuf;
   searchBuf.resize(boundary.size() + 2);
   size_t searchPos = 0;
 
@@ -157,7 +157,7 @@ bool FindMultipartBoundary(raw_istream& is, llvm::StringRef boundary,
 
     // Fast-scan for '-'
     size_t pos = searchBuf.find('-', searchBuf[0] == '-' ? 1 : 0);
-    if (pos == llvm::StringRef::npos) {
+    if (pos == wpi_llvm::StringRef::npos) {
       if (saveBuf) saveBuf->append(searchBuf.data(), searchBuf.size());
     } else {
       if (saveBuf) saveBuf->append(searchBuf.data(), pos);
@@ -170,14 +170,14 @@ bool FindMultipartBoundary(raw_istream& is, llvm::StringRef boundary,
   }
 }
 
-HttpLocation::HttpLocation(const llvm::Twine& url_, bool* error,
+HttpLocation::HttpLocation(const wpi_llvm::Twine& url_, bool* error,
                            std::string* errorMsg)
     : url{url_.str()} {
   // Split apart into components
-  llvm::StringRef query{url};
+  wpi_llvm::StringRef query{url};
 
   // scheme:
-  llvm::StringRef scheme;
+  wpi_llvm::StringRef scheme;
   std::tie(scheme, query) = query.split(':');
   if (!scheme.equals_lower("http")) {
     *errorMsg = "only supports http URLs";
@@ -194,38 +194,38 @@ HttpLocation::HttpLocation(const llvm::Twine& url_, bool* error,
   query = query.drop_front(2);
 
   // user:password@host:port/
-  llvm::StringRef authority;
+  wpi_llvm::StringRef authority;
   std::tie(authority, query) = query.split('/');
 
-  llvm::StringRef userpass, hostport;
+  wpi_llvm::StringRef userpass, hostport;
   std::tie(userpass, hostport) = authority.split('@');
   // split leaves the RHS empty if the split char isn't present...
   if (hostport.empty()) {
     hostport = userpass;
-    userpass = llvm::StringRef{};
+    userpass = wpi_llvm::StringRef{};
   }
 
   if (!userpass.empty()) {
-    llvm::StringRef rawUser, rawPassword;
+    wpi_llvm::StringRef rawUser, rawPassword;
     std::tie(rawUser, rawPassword) = userpass.split(':');
-    llvm::SmallString<64> userBuf, passBuf;
+    wpi_llvm::SmallString<64> userBuf, passBuf;
     user = UnescapeURI(rawUser, userBuf, error);
     if (*error) {
-      llvm::raw_string_ostream oss(*errorMsg);
+      wpi_llvm::raw_string_ostream oss(*errorMsg);
       oss << "could not unescape user \"" << rawUser << "\"";
       oss.flush();
       return;
     }
     password = UnescapeURI(rawPassword, passBuf, error);
     if (*error) {
-      llvm::raw_string_ostream oss(*errorMsg);
+      wpi_llvm::raw_string_ostream oss(*errorMsg);
       oss << "could not unescape password \"" << rawPassword << "\"";
       oss.flush();
       return;
     }
   }
 
-  llvm::StringRef portStr;
+  wpi_llvm::StringRef portStr;
   std::tie(host, portStr) = hostport.rsplit(':');
   if (host.empty()) {
     *errorMsg = "host is empty";
@@ -235,7 +235,7 @@ HttpLocation::HttpLocation(const llvm::Twine& url_, bool* error,
   if (portStr.empty()) {
     port = 80;
   } else if (portStr.getAsInteger(10, port)) {
-    llvm::raw_string_ostream oss(*errorMsg);
+    wpi_llvm::raw_string_ostream oss(*errorMsg);
     oss << "port \"" << portStr << "\" is not an integer";
     oss.flush();
     *error = true;
@@ -249,27 +249,27 @@ HttpLocation::HttpLocation(const llvm::Twine& url_, bool* error,
   // Split query string into parameters
   while (!query.empty()) {
     // split out next param and value
-    llvm::StringRef rawParam, rawValue;
+    wpi_llvm::StringRef rawParam, rawValue;
     std::tie(rawParam, query) = query.split('&');
     if (rawParam.empty()) continue;  // ignore "&&"
     std::tie(rawParam, rawValue) = rawParam.split('=');
 
     // unescape param
     *error = false;
-    llvm::SmallString<64> paramBuf;
-    llvm::StringRef param = UnescapeURI(rawParam, paramBuf, error);
+    wpi_llvm::SmallString<64> paramBuf;
+    wpi_llvm::StringRef param = UnescapeURI(rawParam, paramBuf, error);
     if (*error) {
-      llvm::raw_string_ostream oss(*errorMsg);
+      wpi_llvm::raw_string_ostream oss(*errorMsg);
       oss << "could not unescape parameter \"" << rawParam << "\"";
       oss.flush();
       return;
     }
 
     // unescape value
-    llvm::SmallString<64> valueBuf;
-    llvm::StringRef value = UnescapeURI(rawValue, valueBuf, error);
+    wpi_llvm::SmallString<64> valueBuf;
+    wpi_llvm::StringRef value = UnescapeURI(rawValue, valueBuf, error);
     if (*error) {
-      llvm::raw_string_ostream oss(*errorMsg);
+      wpi_llvm::raw_string_ostream oss(*errorMsg);
       oss << "could not unescape value \"" << rawValue << "\"";
       oss.flush();
       return;
@@ -283,7 +283,7 @@ HttpLocation::HttpLocation(const llvm::Twine& url_, bool* error,
 
 void HttpRequest::SetAuth(const HttpLocation& loc) {
   if (!loc.user.empty()) {
-    llvm::SmallString<64> userpass;
+    wpi_llvm::SmallString<64> userpass;
     userpass += loc.user;
     userpass += ':';
     userpass += loc.password;
@@ -302,15 +302,15 @@ bool HttpConnection::Handshake(const HttpRequest& request,
   os.flush();
 
   // read first line of response
-  llvm::SmallString<64> lineBuf;
-  llvm::StringRef line = is.getline(lineBuf, 1024).rtrim();
+  wpi_llvm::SmallString<64> lineBuf;
+  wpi_llvm::StringRef line = is.getline(lineBuf, 1024).rtrim();
   if (is.has_error()) {
     *warnMsg = "disconnected before response";
     return false;
   }
 
   // see if we got a HTTP 200 response
-  llvm::StringRef httpver, code, codeText;
+  wpi_llvm::StringRef httpver, code, codeText;
   std::tie(httpver, line) = line.split(' ');
   std::tie(code, codeText) = line.split(' ');
   if (!httpver.startswith("HTTP")) {
@@ -318,7 +318,7 @@ bool HttpConnection::Handshake(const HttpRequest& request,
     return false;
   }
   if (code != "200") {
-    llvm::raw_string_ostream oss(*warnMsg);
+    wpi_llvm::raw_string_ostream oss(*warnMsg);
     oss << "received " << code << " " << codeText << " response";
     oss.flush();
     return false;

--- a/src/main/native/cpp/support/hostname.cpp
+++ b/src/main/native/cpp/support/hostname.cpp
@@ -51,15 +51,15 @@ std::string GetHostname() {
   return name;
 }
 
-llvm::StringRef GetHostname(llvm::SmallVectorImpl<char>& name) {
+wpi_llvm::StringRef GetHostname(wpi_llvm::SmallVectorImpl<char>& name) {
   // Use a tmp array to not require the SmallVector to be too large.
   char tmpName[256];
   if (!GetHostnameImpl(tmpName, sizeof(tmpName))) {
-    return llvm::StringRef{};
+    return wpi_llvm::StringRef{};
   }
   name.clear();
   name.append(tmpName, tmpName + std::strlen(tmpName) + 1);
 
-  return llvm::StringRef{name.data(), name.size(), true};
+  return wpi_llvm::StringRef{name.data(), name.size(), true};
 }
 }  // namespace wpi

--- a/src/main/native/cpp/support/json.cpp
+++ b/src/main/native/cpp/support/json.cpp
@@ -141,7 +141,7 @@ json::json_value::json_value(value_t t)
     }
 }
 
-json::json_value::json_value(llvm::StringRef value)
+json::json_value::json_value(wpi_llvm::StringRef value)
 {
     string = create<std::string>(value);
 }
@@ -727,7 +727,7 @@ void json::push_back(const json& val)
     m_value.array->push_back(val);
 }
 
-void json::push_back(const std::pair<llvm::StringRef, json>& val)
+void json::push_back(const std::pair<wpi_llvm::StringRef, json>& val)
 {
     // push_back only works for null objects or objects
     if (!(is_null() || is_object()))
@@ -752,7 +752,7 @@ void json::push_back(std::initializer_list<json> init)
     if (is_object() && init.size() == 2 && init.begin()->is_string())
     {
         const std::string key = *init.begin();
-        push_back(std::pair<llvm::StringRef, json>(key, *(init.begin() + 1)));
+        push_back(std::pair<wpi_llvm::StringRef, json>(key, *(init.begin() + 1)));
     }
     else
     {
@@ -802,7 +802,7 @@ json::const_reference json::at(size_type idx) const
     }
 }
 
-json::reference json::at(llvm::StringRef key)
+json::reference json::at(wpi_llvm::StringRef key)
 {
     // at only works for objects
     if (is_object())
@@ -820,7 +820,7 @@ json::reference json::at(llvm::StringRef key)
     }
 }
 
-json::const_reference json::at(llvm::StringRef key) const
+json::const_reference json::at(wpi_llvm::StringRef key) const
 {
     // at only works for objects
     if (is_object())
@@ -877,7 +877,7 @@ json::const_reference json::operator[](size_type idx) const
     JSON_THROW(type_error::create(305, "cannot use operator[] with " + type_name()));
 }
 
-json::reference json::operator[](llvm::StringRef key)
+json::reference json::operator[](wpi_llvm::StringRef key)
 {
     // implicitly convert null value to an empty object
     if (is_null())
@@ -896,7 +896,7 @@ json::reference json::operator[](llvm::StringRef key)
     JSON_THROW(type_error::create(305, "cannot use operator[] with " + type_name()));
 }
 
-json::const_reference json::operator[](llvm::StringRef key) const
+json::const_reference json::operator[](wpi_llvm::StringRef key) const
 {
     // const operator[] only works for objects
     if (is_object())
@@ -960,7 +960,7 @@ json::const_reference json::back() const
     }
 }
 
-json::size_type json::erase(llvm::StringRef key)
+json::size_type json::erase(wpi_llvm::StringRef key)
 {
     // this erase only works for objects
     if (is_object())
@@ -989,7 +989,7 @@ void json::erase(const size_type idx)
     }
 }
 
-json::iterator json::find(llvm::StringRef key)
+json::iterator json::find(wpi_llvm::StringRef key)
 {
     auto result = end();
 
@@ -1001,7 +1001,7 @@ json::iterator json::find(llvm::StringRef key)
     return result;
 }
 
-json::const_iterator json::find(llvm::StringRef key) const
+json::const_iterator json::find(wpi_llvm::StringRef key) const
 {
     auto result = cend();
 
@@ -1173,8 +1173,8 @@ std::size_t hash<wpi::json>::operator()(const wpi::json& j) const
 {
     // a naive hashing via the string representation
     const auto& h = hash<std::string>();
-    llvm::SmallVector<char, 128> buf;
-    llvm::raw_svector_ostream os(buf);
+    wpi_llvm::SmallVector<char, 128> buf;
+    wpi_llvm::raw_svector_ostream os(buf);
     j.dump(os);
     return h(os.str());
 }

--- a/src/main/native/cpp/support/json_binary_reader.cpp
+++ b/src/main/native/cpp/support/json_binary_reader.cpp
@@ -627,9 +627,9 @@ json binary_reader::parse_cbor(bool get_char)
         default: // anything else (0xFF is handled inside the other types)
         {
             std::string s;
-            llvm::raw_string_ostream ss(s);
+            wpi_llvm::raw_string_ostream ss(s);
             ss << "error reading CBOR; last byte: ";
-            ss << llvm::format_hex(current, 2);
+            ss << wpi_llvm::format_hex(current, 2);
             JSON_THROW(json::parse_error::create(112, chars_read, ss.str()));
         }
     }
@@ -709,9 +709,9 @@ std::string binary_reader::get_cbor_string()
         default:
         {
             std::string s;
-            llvm::raw_string_ostream ss(s);
+            wpi_llvm::raw_string_ostream ss(s);
             ss << "expected a CBOR string; last byte: ";
-            ss << llvm::format_hex(current, 2);
+            ss << wpi_llvm::format_hex(current, 2);
             JSON_THROW(json::parse_error::create(113, chars_read, ss.str()));
         }
     }
@@ -1113,9 +1113,9 @@ json binary_reader::parse_msgpack()
         default: // anything else
         {
             std::string s;
-            llvm::raw_string_ostream ss(s);
+            wpi_llvm::raw_string_ostream ss(s);
             ss << "error reading MessagePack; last byte: ";
-            ss << llvm::format_hex(current, 2);
+            ss << wpi_llvm::format_hex(current, 2);
             JSON_THROW(json::parse_error::create(112, chars_read, ss.str()));
         }
     }
@@ -1186,9 +1186,9 @@ std::string binary_reader::get_msgpack_string()
         default:
         {
             std::string s;
-            llvm::raw_string_ostream ss(s);
+            wpi_llvm::raw_string_ostream ss(s);
             ss << "expected a MessagePack string; last byte: ";
-            ss << llvm::format_hex(current, 2);
+            ss << wpi_llvm::format_hex(current, 2);
             JSON_THROW(json::parse_error::create(113, chars_read, ss.str()));
         }
     }
@@ -1212,7 +1212,7 @@ json json::from_cbor(wpi::raw_istream& is)
     return br.parse_cbor();
 }
 
-json json::from_cbor(llvm::StringRef s)
+json json::from_cbor(wpi_llvm::StringRef s)
 {
     wpi::raw_mem_istream is(s.data(), s.size());
     binary_reader br(is);
@@ -1225,7 +1225,7 @@ json json::from_msgpack(wpi::raw_istream& is)
     return br.parse_msgpack();
 }
 
-json json::from_msgpack(llvm::StringRef s)
+json json::from_msgpack(wpi_llvm::StringRef s)
 {
     wpi::raw_mem_istream is(s.data(), s.size());
     binary_reader br(is);

--- a/src/main/native/cpp/support/json_binary_writer.cpp
+++ b/src/main/native/cpp/support/json_binary_writer.cpp
@@ -56,7 +56,7 @@ class json::binary_writer
 
     @param[in] adapter  output adapter to write to
     */
-    explicit binary_writer(llvm::raw_ostream& s)
+    explicit binary_writer(wpi_llvm::raw_ostream& s)
         : is_little_endian(little_endianess()), o(s)
     {
     }
@@ -88,12 +88,12 @@ class json::binary_writer
     /*!
     @brief[in] str string to serialize
     */
-    void write_cbor_string(llvm::StringRef str);
+    void write_cbor_string(wpi_llvm::StringRef str);
 
     /*!
     @brief[in] str string to serialize
     */
-    void write_msgpack_string(llvm::StringRef str);
+    void write_msgpack_string(wpi_llvm::StringRef str);
 
     /*
     @brief write a number to output input
@@ -132,7 +132,7 @@ class json::binary_writer
     const bool is_little_endian = true;
 
     /// the output
-    llvm::raw_ostream& o;
+    wpi_llvm::raw_ostream& o;
 };
 
 void json::binary_writer::write_cbor(const json& j)
@@ -345,7 +345,7 @@ void json::binary_writer::write_cbor(const json& j)
     }
 }
 
-void json::binary_writer::write_cbor_string(llvm::StringRef str)
+void json::binary_writer::write_cbor_string(wpi_llvm::StringRef str)
 {
     // step 1: write control byte and the string length
     const auto N = str.size();
@@ -587,7 +587,7 @@ void json::binary_writer::write_msgpack(const json& j)
     }
 }
 
-void json::binary_writer::write_msgpack_string(llvm::StringRef str)
+void json::binary_writer::write_msgpack_string(wpi_llvm::StringRef str)
 {
     // step 1: write control byte and the string length
     const auto N = str.size();
@@ -619,15 +619,15 @@ void json::binary_writer::write_msgpack_string(llvm::StringRef str)
     o << str;
 }
 
-void json::to_cbor(llvm::raw_ostream& os, const json& j)
+void json::to_cbor(wpi_llvm::raw_ostream& os, const json& j)
 {
     binary_writer bw(os);
     bw.write_cbor(j);
 }
 
-llvm::StringRef json::to_cbor(const json& j, llvm::SmallVectorImpl<char> buf)
+wpi_llvm::StringRef json::to_cbor(const json& j, wpi_llvm::SmallVectorImpl<char> buf)
 {
-    llvm::raw_svector_ostream os(buf);
+    wpi_llvm::raw_svector_ostream os(buf);
     binary_writer bw(os);
     bw.write_cbor(j);
     return os.str();
@@ -636,22 +636,22 @@ llvm::StringRef json::to_cbor(const json& j, llvm::SmallVectorImpl<char> buf)
 std::string json::to_cbor(const json& j)
 {
     std::string s;
-    llvm::raw_string_ostream os(s);
+    wpi_llvm::raw_string_ostream os(s);
     binary_writer bw(os);
     bw.write_cbor(j);
     os.flush();
     return s;
 }
 
-void json::to_msgpack(llvm::raw_ostream& os, const json& j)
+void json::to_msgpack(wpi_llvm::raw_ostream& os, const json& j)
 {
     binary_writer bw(os);
     bw.write_msgpack(j);
 }
 
-llvm::StringRef json::to_msgpack(const json& j, llvm::SmallVectorImpl<char> buf)
+wpi_llvm::StringRef json::to_msgpack(const json& j, wpi_llvm::SmallVectorImpl<char> buf)
 {
-    llvm::raw_svector_ostream os(buf);
+    wpi_llvm::raw_svector_ostream os(buf);
     binary_writer bw(os);
     bw.write_msgpack(j);
     return os.str();
@@ -660,7 +660,7 @@ llvm::StringRef json::to_msgpack(const json& j, llvm::SmallVectorImpl<char> buf)
 std::string json::to_msgpack(const json& j)
 {
     std::string s;
-    llvm::raw_string_ostream os(s);
+    wpi_llvm::raw_string_ostream os(s);
     binary_writer bw(os);
     bw.write_msgpack(j);
     os.flush();

--- a/src/main/native/cpp/support/json_parser.cpp
+++ b/src/main/native/cpp/support/json_parser.cpp
@@ -259,7 +259,7 @@ class lexer
     }
 
     /// return string value
-    llvm::StringRef get_string()
+    wpi_llvm::StringRef get_string()
     {
         return yytext.str();
     }
@@ -303,10 +303,10 @@ class lexer
     size_t chars_read = 0;
 
     /// buffer for raw byte sequence of the current token
-    llvm::SmallString<128> token_string;
+    wpi_llvm::SmallString<128> token_string;
 
     /// buffer for variable-length tokens (numbers, strings)
-    llvm::SmallString<128> yytext;
+    wpi_llvm::SmallString<128> yytext;
 
     /// a description of occurred lexer errors
     std::string error_message = "";
@@ -616,8 +616,8 @@ int lexer::get_codepoint()
 std::string lexer::codepoint_to_string(int codepoint)
 {
     std::string s;
-    llvm::raw_string_ostream ss(s);
-    ss << "U+" << llvm::format_hex_no_prefix(codepoint, 4, true);
+    wpi_llvm::raw_string_ostream ss(s);
+    ss << "U+" << wpi_llvm::format_hex_no_prefix(codepoint, 4, true);
     return ss.str();
 }
 
@@ -2073,7 +2073,7 @@ void json::parser::unexpect(lexer::token_type t) const
     }
 }
 
-json json::parse(llvm::StringRef s, const parser_callback_t cb)
+json json::parse(wpi_llvm::StringRef s, const parser_callback_t cb)
 {
     wpi::raw_mem_istream is(s.data(), s.size());
     return parser(is, cb).parse(true);

--- a/src/main/native/cpp/support/json_pointer.cpp
+++ b/src/main/native/cpp/support/json_pointer.cpp
@@ -505,7 +505,7 @@ json json::json_pointer::unflatten(const json& value)
     }
 
     // we need to iterate over the object values in sorted key order
-    llvm::SmallVector<llvm::StringMapConstIterator<json>, 64> sorted;
+    wpi_llvm::SmallVector<wpi_llvm::StringMapConstIterator<json>, 64> sorted;
     for (auto i = value.m_value.object->begin(),
          end = value.m_value.object->end(); i != end; ++i)
     {
@@ -516,8 +516,8 @@ json json::json_pointer::unflatten(const json& value)
         sorted.push_back(i);
     }
     std::sort(sorted.begin(), sorted.end(),
-              [](const llvm::StringMapConstIterator<json>& a,
-                 const llvm::StringMapConstIterator<json>& b) {
+              [](const wpi_llvm::StringMapConstIterator<json>& a,
+                 const wpi_llvm::StringMapConstIterator<json>& b) {
                 return a->getKey() < b->getKey();
               });
 

--- a/src/main/native/cpp/support/json_serializer.cpp
+++ b/src/main/native/cpp/support/json_serializer.cpp
@@ -221,7 +221,7 @@ void json::serializer::dump(const json& val,
     }
 }
 
-void json::serializer::dump_escaped(llvm::StringRef s) const
+void json::serializer::dump_escaped(wpi_llvm::StringRef s) const
 {
     for (const auto& c : s)
     {
@@ -307,8 +307,8 @@ void json::serializer::dump_escaped(llvm::StringRef s) const
             {
                 // print character c as \uxxxx
                 o << "\\u00";
-                o << llvm::hexdigit((c >> 4) & 0xf, true);
-                o << llvm::hexdigit((c >> 0) & 0xf, true);
+                o << wpi_llvm::hexdigit((c >> 4) & 0xf, true);
+                o << wpi_llvm::hexdigit((c >> 0) & 0xf, true);
                 break;
             }
 
@@ -349,7 +349,7 @@ void json::serializer::dump_float(double x)
     static constexpr auto d = std::numeric_limits<double>::digits10;
 
     // the actual conversion
-    llvm::SmallString<64> number_buffer;
+    wpi_llvm::SmallString<64> number_buffer;
     number_buffer.resize(64);
     std::ptrdiff_t len = snprintf(number_buffer.data(), number_buffer.size(),
                                   "%.*g", d, x);
@@ -401,7 +401,7 @@ void json::serializer::dump_float(double x)
 
 namespace wpi {
 
-llvm::raw_ostream& operator<<(llvm::raw_ostream& o, const json& j)
+wpi_llvm::raw_ostream& operator<<(wpi_llvm::raw_ostream& o, const json& j)
 {
     j.dump(o, 0);
     return o;
@@ -412,13 +412,13 @@ llvm::raw_ostream& operator<<(llvm::raw_ostream& o, const json& j)
 std::string json::dump(int indent) const
 {
     std::string s;
-    llvm::raw_string_ostream os(s);
+    wpi_llvm::raw_string_ostream os(s);
     dump(os, indent);
     os.flush();
     return s;
 }
 
-void json::dump(llvm::raw_ostream& os, int indent) const
+void json::dump(wpi_llvm::raw_ostream& os, int indent) const
 {
     serializer s(os);
 

--- a/src/main/native/cpp/support/json_serializer.h
+++ b/src/main/native/cpp/support/json_serializer.h
@@ -53,7 +53,7 @@ class json::serializer
     @param[in] s  output stream to serialize to
     @param[in] ichar  indentation character to use
     */
-    explicit serializer(llvm::raw_ostream& s)
+    explicit serializer(wpi_llvm::raw_ostream& s)
         : o(s), loc(std::localeconv()),
           thousands_sep(!loc->thousands_sep ? '\0' : loc->thousands_sep[0]),
           decimal_point(!loc->decimal_point ? '\0' : loc->decimal_point[0])
@@ -93,7 +93,7 @@ class json::serializer
 
     @complexity Linear in the length of string @a s.
     */
-    void dump_escaped(llvm::StringRef s) const;
+    void dump_escaped(wpi_llvm::StringRef s) const;
 
     /*!
     @brief dump a floating-point number
@@ -107,7 +107,7 @@ class json::serializer
 
   private:
     /// the output of the serializer
-    llvm::raw_ostream& o;
+    wpi_llvm::raw_ostream& o;
 
     /// the locale
     const std::lconv* loc = nullptr;

--- a/src/main/native/cpp/support/leb128.cpp
+++ b/src/main/native/cpp/support/leb128.cpp
@@ -39,7 +39,7 @@ uint64_t SizeUleb128(uint64_t val) {
  * encodings refer to section "7.6 - Variable Length Data". Return
  * the number of bytes written.
  */
-uint64_t WriteUleb128(llvm::SmallVectorImpl<char>& dest, uint64_t val) {
+uint64_t WriteUleb128(wpi_llvm::SmallVectorImpl<char>& dest, uint64_t val) {
   size_t count = 0;
 
   do {

--- a/src/main/native/cpp/support/raw_istream.cpp
+++ b/src/main/native/cpp/support/raw_istream.cpp
@@ -34,21 +34,21 @@
 
 using namespace wpi;
 
-llvm::StringRef raw_istream::getline(llvm::SmallVectorImpl<char>& buf,
+wpi_llvm::StringRef raw_istream::getline(wpi_llvm::SmallVectorImpl<char>& buf,
                                      int maxLen) {
   buf.clear();
   for (int i = 0; i < maxLen; ++i) {
     char c;
     read(c);
-    if (has_error()) return llvm::StringRef{buf.data(), buf.size()};
+    if (has_error()) return wpi_llvm::StringRef{buf.data(), buf.size()};
     if (c == '\r') continue;
     buf.push_back(c);
     if (c == '\n') break;
   }
-  return llvm::StringRef{buf.data(), buf.size()};
+  return wpi_llvm::StringRef{buf.data(), buf.size()};
 }
 
-raw_mem_istream::raw_mem_istream(llvm::StringRef mem)
+raw_mem_istream::raw_mem_istream(wpi_llvm::StringRef mem)
     : raw_mem_istream(mem.data(), mem.size()) {}
 
 void raw_mem_istream::close() {}
@@ -65,7 +65,7 @@ void raw_mem_istream::read_impl(void* data, size_t len) {
   m_left -= len;
 }
 
-static int getFD(const llvm::Twine& Filename, std::error_code& EC) {
+static int getFD(const wpi_llvm::Twine& Filename, std::error_code& EC) {
   // Handle "-" as stdin. Note that when we do this, we consider ourself
   // the owner of stdin. This means that we can do things like close the
   // file descriptor when we're done and set the "binary" flag globally.
@@ -76,14 +76,14 @@ static int getFD(const llvm::Twine& Filename, std::error_code& EC) {
 
   int FD;
 
-  EC = llvm::sys::fs::openFileForRead(Filename, FD);
+  EC = wpi_llvm::sys::fs::openFileForRead(Filename, FD);
   if (EC) return -1;
 
   EC = std::error_code();
   return FD;
 }
 
-raw_fd_istream::raw_fd_istream(const llvm::Twine& filename, std::error_code& ec,
+raw_fd_istream::raw_fd_istream(const wpi_llvm::Twine& filename, std::error_code& ec,
                                size_t bufSize)
     : raw_fd_istream(getFD(filename, ec), true, bufSize) {}
 

--- a/src/main/native/cpp/support/sha1.cpp
+++ b/src/main/native/cpp/support/sha1.cpp
@@ -214,7 +214,7 @@ static void buffer_to_block(const unsigned char* buffer,
 
 SHA1::SHA1() { reset(digest, buf_size, transforms); }
 
-void SHA1::Update(llvm::StringRef s) {
+void SHA1::Update(wpi_llvm::StringRef s) {
   raw_mem_istream is(s);
   Update(is);
 }
@@ -237,7 +237,7 @@ void SHA1::Update(raw_istream& is) {
  */
 
 static void finalize(uint32_t digest[], unsigned char* buffer, size_t& buf_size,
-                     uint64_t& transforms, llvm::raw_ostream& os) {
+                     uint64_t& transforms, wpi_llvm::raw_ostream& os) {
   /* Total number of hashed bits */
   uint64_t total_bits = (transforms * BLOCK_BYTES + buf_size) * 8;
 
@@ -277,22 +277,22 @@ static void finalize(uint32_t digest[], unsigned char* buffer, size_t& buf_size,
 
 std::string SHA1::Final() {
   std::string out;
-  llvm::raw_string_ostream os(out);
+  wpi_llvm::raw_string_ostream os(out);
 
   finalize(digest, buffer, buf_size, transforms, os);
 
   return os.str();
 }
 
-llvm::StringRef SHA1::Final(llvm::SmallVectorImpl<char>& buf) {
-  llvm::raw_svector_ostream os(buf);
+wpi_llvm::StringRef SHA1::Final(wpi_llvm::SmallVectorImpl<char>& buf) {
+  wpi_llvm::raw_svector_ostream os(buf);
 
   finalize(digest, buffer, buf_size, transforms, os);
 
   return os.str();
 }
 
-std::string SHA1::FromFile(llvm::StringRef filename) {
+std::string SHA1::FromFile(wpi_llvm::StringRef filename) {
   std::error_code ec;
   raw_fd_istream stream(filename, ec);
   SHA1 checksum;

--- a/src/main/native/cpp/tcpsockets/TCPAcceptor.cpp
+++ b/src/main/native/cpp/tcpsockets/TCPAcceptor.cpp
@@ -85,7 +85,7 @@ int TCPAcceptor::start() {
   address.sin_family = PF_INET;
   if (m_address.size() > 0) {
 #ifdef _WIN32
-    llvm::SmallString<128> addr_copy(m_address);
+    wpi_llvm::SmallString<128> addr_copy(m_address);
     addr_copy.push_back('\0');
     int res = InetPton(PF_INET, addr_copy.data(), &(address.sin_addr));
 #else
@@ -139,7 +139,7 @@ void TCPAcceptor::shutdown() {
 
   std::memset(&address, 0, sizeof(address));
   address.sin_family = PF_INET;
-  llvm::SmallString<128> addr_copy;
+  wpi_llvm::SmallString<128> addr_copy;
   if (m_address.size() > 0)
     addr_copy = m_address;
   else

--- a/src/main/native/cpp/tcpsockets/TCPConnector.cpp
+++ b/src/main/native/cpp/tcpsockets/TCPConnector.cpp
@@ -89,7 +89,7 @@ std::unique_ptr<NetworkStream> TCPConnector::connect(const char* server,
   address.sin_family = AF_INET;
   if (ResolveHostName(server, &(address.sin_addr)) != 0) {
 #ifdef _WIN32
-    llvm::SmallString<128> addr_copy(server);
+    wpi_llvm::SmallString<128> addr_copy(server);
     addr_copy.push_back('\0');
     int res = InetPton(PF_INET, addr_copy.data(), &(address.sin_addr));
 #else

--- a/src/main/native/cpp/tcpsockets/TCPConnector_parallel.cpp
+++ b/src/main/native/cpp/tcpsockets/TCPConnector_parallel.cpp
@@ -27,7 +27,7 @@ using namespace wpi;
 #endif
 
 std::unique_ptr<NetworkStream> TCPConnector::connect_parallel(
-    llvm::ArrayRef<std::pair<const char*, int>> servers, Logger& logger,
+    wpi_llvm::ArrayRef<std::pair<const char*, int>> servers, Logger& logger,
     int timeout) {
   if (servers.empty()) return nullptr;
 
@@ -35,9 +35,9 @@ std::unique_ptr<NetworkStream> TCPConnector::connect_parallel(
   struct GlobalState {
     wpi::mutex mtx;
 #ifdef HAVE_THREAD_LOCAL
-    llvm::SmallSet<std::pair<std::string, int>, 16> active;
+    wpi_llvm::SmallSet<std::pair<std::string, int>, 16> active;
 #else
-    llvm::SmallSet<std::tuple<std::thread::id, std::string, int>, 16> active;
+    wpi_llvm::SmallSet<std::tuple<std::thread::id, std::string, int>, 16> active;
 #endif
   };
 #ifdef HAVE_THREAD_LOCAL

--- a/src/main/native/cpp/tcpsockets/TCPStream.cpp
+++ b/src/main/native/cpp/tcpsockets/TCPStream.cpp
@@ -162,7 +162,7 @@ void TCPStream::close() {
   m_sd = -1;
 }
 
-llvm::StringRef TCPStream::getPeerIP() const { return m_peerIP; }
+wpi_llvm::StringRef TCPStream::getPeerIP() const { return m_peerIP; }
 
 int TCPStream::getPeerPort() const { return m_peerPort; }
 

--- a/src/main/native/cpp/udpsockets/UDPClient.cpp
+++ b/src/main/native/cpp/udpsockets/UDPClient.cpp
@@ -25,7 +25,7 @@ using namespace wpi;
 
 UDPClient::UDPClient(Logger& logger) : UDPClient("", logger) {}
 
-UDPClient::UDPClient(llvm::StringRef address, Logger& logger)
+UDPClient::UDPClient(wpi_llvm::StringRef address, Logger& logger)
     : m_lsd(0), m_address(address), m_logger(logger) {}
 
 UDPClient::UDPClient(UDPClient&& other)
@@ -72,7 +72,7 @@ int UDPClient::start() {
   addr.sin_family = AF_INET;
   if (m_address.size() > 0) {
 #ifdef _WIN32
-    llvm::SmallString<128> addr_copy(m_address);
+    wpi_llvm::SmallString<128> addr_copy(m_address);
     addr_copy.push_back('\0');
     int res = InetPton(PF_INET, addr_copy.data(), &(addr.sin_addr));
 #else
@@ -109,14 +109,14 @@ void UDPClient::shutdown() {
   }
 }
 
-int UDPClient::send(llvm::ArrayRef<uint8_t> data, llvm::StringRef server,
+int UDPClient::send(wpi_llvm::ArrayRef<uint8_t> data, wpi_llvm::StringRef server,
                     int port) {
   // server must be a resolvable IP address
   struct sockaddr_in addr;
   std::memset(&addr, 0, sizeof(addr));
   addr.sin_family = AF_INET;
   if (server.size() > 0) {
-    llvm::SmallVector<char, 128> addr_store;
+    wpi_llvm::SmallVector<char, 128> addr_store;
     auto remoteAddr = server.c_str(addr_store);
 #ifdef _WIN32
     int res = InetPton(AF_INET, remoteAddr, &(addr.sin_addr));
@@ -140,13 +140,13 @@ int UDPClient::send(llvm::ArrayRef<uint8_t> data, llvm::StringRef server,
   return result;
 }
 
-int UDPClient::send(llvm::StringRef data, llvm::StringRef server, int port) {
+int UDPClient::send(wpi_llvm::StringRef data, wpi_llvm::StringRef server, int port) {
   // server must be a resolvable IP address
   struct sockaddr_in addr;
   std::memset(&addr, 0, sizeof(addr));
   addr.sin_family = AF_INET;
   if (server.size() > 0) {
-    llvm::SmallVector<char, 128> addr_store;
+    wpi_llvm::SmallVector<char, 128> addr_store;
     auto remoteAddr = server.c_str(addr_store);
 #ifdef _WIN32
     int res = InetPton(AF_INET, remoteAddr, &(addr.sin_addr));

--- a/src/main/native/include/llvm/AlignOf.h
+++ b/src/main/native/include/llvm/AlignOf.h
@@ -19,7 +19,7 @@
 #include <cstddef>
 #include <type_traits>
 
-namespace llvm {
+namespace wpi_llvm {
 
 namespace detail {
 
@@ -71,8 +71,8 @@ template <typename T>
 struct AlignOf {
 #ifndef _MSC_VER
   // Avoid warnings from GCC like:
-  //   comparison between 'enum llvm::AlignOf<X>::<anonymous>' and 'enum
-  //   llvm::AlignOf<Y>::<anonymous>' [-Wenum-compare]
+  //   comparison between 'enum wpi_llvm::AlignOf<X>::<anonymous>' and 'enum
+  //   wpi_llvm::AlignOf<Y>::<anonymous>' [-Wenum-compare]
   // by using constexpr instead of enum.
   // (except on MSVC, since it doesn't support constexpr yet).
   static constexpr unsigned Alignment = static_cast<unsigned int>(
@@ -80,7 +80,7 @@ struct AlignOf {
 #else
   enum {
     Alignment = static_cast<unsigned int>(
-        sizeof(::llvm::detail::AlignmentCalcImpl<T>) - sizeof(T))
+        sizeof(::wpi_llvm::detail::AlignmentCalcImpl<T>) - sizeof(T))
   };
 #endif
   enum { Alignment_GreaterEqual_2Bytes = Alignment >= 2 ? 1 : 0 };
@@ -248,12 +248,12 @@ template <typename T1,
           typename T2 = char, typename T3 = char, typename T4 = char,
           typename T5 = char, typename T6 = char, typename T7 = char,
           typename T8 = char, typename T9 = char, typename T10 = char>
-struct AlignedCharArrayUnion : llvm::AlignedCharArray<
-    AlignOf<llvm::detail::AlignerImpl<T1, T2, T3, T4, T5,
+struct AlignedCharArrayUnion : wpi_llvm::AlignedCharArray<
+    AlignOf<wpi_llvm::detail::AlignerImpl<T1, T2, T3, T4, T5,
                                       T6, T7, T8, T9, T10> >::Alignment,
-    sizeof(::llvm::detail::SizerImpl<T1, T2, T3, T4, T5,
+    sizeof(::wpi_llvm::detail::SizerImpl<T1, T2, T3, T4, T5,
                                      T6, T7, T8, T9, T10>)> {
 };
-} // end namespace llvm
+} // end namespace wpi_llvm
 
 #endif // LLVM_SUPPORT_ALIGNOF_H

--- a/src/main/native/include/llvm/ArrayRef.h
+++ b/src/main/native/include/llvm/ArrayRef.h
@@ -16,7 +16,7 @@
 #include "llvm/SmallVector.h"
 #include <vector>
 
-namespace llvm {
+namespace wpi_llvm {
   /// ArrayRef - Represent a constant reference to an array (0 or more elements
   /// consecutively in memory), i.e. a start pointer and a length.  It allows
   /// various APIs to take consecutive elements easily and conveniently.
@@ -392,6 +392,6 @@ namespace llvm {
   template <typename T> hash_code hash_value(ArrayRef<T> S) {
     return hash_combine_range(S.begin(), S.end());
   }
-} // end namespace llvm
+} // end namespace wpi_llvm
 
 #endif // LLVM_ADT_ARRAYREF_H

--- a/src/main/native/include/llvm/ConvertUTF.h
+++ b/src/main/native/include/llvm/ConvertUTF.h
@@ -183,7 +183,7 @@ unsigned getNumBytesForUTF8(UTF8 firstByte);
 #include "llvm/ArrayRef.h"
 #include "llvm/StringRef.h"
 
-namespace llvm {
+namespace wpi_llvm {
 
 /**
  * Convert an Unicode code point to UTF8 sequence.
@@ -246,7 +246,7 @@ bool convertUTF16ToUTF8String(ArrayRef<UTF16> SrcUTF16,
 bool convertUTF8ToUTF16String(StringRef SrcUTF8,
                               SmallVectorImpl<UTF16> &DstUTF16);
 
-} /* end namespace llvm */
+} /* end namespace wpi_llvm */
 
 #endif
 

--- a/src/main/native/include/llvm/DenseMap.h
+++ b/src/main/native/include/llvm/DenseMap.h
@@ -30,7 +30,7 @@
 #include <new>
 #include <utility>
 
-namespace llvm {
+namespace wpi_llvm {
 
 namespace detail {
 // We extend a pair to allow users to override the bucket type with their own
@@ -1115,6 +1115,6 @@ capacity_in_bytes(const DenseMap<KeyT, ValueT, KeyInfoT> &X) {
   return X.getMemorySize();
 }
 
-} // end namespace llvm
+} // end namespace wpi_llvm
 
 #endif

--- a/src/main/native/include/llvm/DenseMapInfo.h
+++ b/src/main/native/include/llvm/DenseMapInfo.h
@@ -20,7 +20,7 @@
 #include "llvm/PointerLikeTypeTraits.h"
 #include "llvm/type_traits.h"
 
-namespace llvm {
+namespace wpi_llvm {
 
 template<typename T>
 struct DenseMapInfo {
@@ -246,6 +246,6 @@ template <typename T> struct DenseMapInfo<ArrayRef<T>> {
   }
 };
 
-} // end namespace llvm
+} // end namespace wpi_llvm
 
 #endif

--- a/src/main/native/include/llvm/EpochTracker.h
+++ b/src/main/native/include/llvm/EpochTracker.h
@@ -18,7 +18,7 @@
 
 #include <cstdint>
 
-namespace llvm {
+namespace wpi_llvm {
 
 #ifdef NDEBUG //ifndef LLVM_ENABLE_ABI_BREAKING_CHECKS
 
@@ -92,6 +92,6 @@ public:
 
 #endif // LLVM_ENABLE_ABI_BREAKING_CHECKS
 
-} // namespace llvm
+} // namespace wpi_llvm
 
 #endif

--- a/src/main/native/include/llvm/FileSystem.h
+++ b/src/main/native/include/llvm/FileSystem.h
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file declares the llvm::sys::fs namespace. It is designed after
+// This file declares the wpi_llvm::sys::fs namespace. It is designed after
 // TR2/boost filesystem (v3), but modified to remove exception handling and the
 // path class.
 //
@@ -39,7 +39,7 @@
 #include <tuple>
 #include <vector>
 
-namespace llvm {
+namespace wpi_llvm {
 namespace sys {
 namespace fs {
 
@@ -663,6 +663,6 @@ public:
 
 } // end namespace fs
 } // end namespace sys
-} // end namespace llvm
+} // end namespace wpi_llvm
 
 #endif // LLVM_SUPPORT_FILESYSTEM_H

--- a/src/main/native/include/llvm/Format.h
+++ b/src/main/native/include/llvm/Format.h
@@ -30,7 +30,7 @@
 #include <cstdio>
 #include <tuple>
 
-namespace llvm {
+namespace wpi_llvm {
 
 /// This is a helper class used for handling formatted output.  It is the
 /// abstract base class of a templated derived class.
@@ -197,6 +197,6 @@ inline FormattedNumber format_decimal(int64_t N, unsigned Width) {
   return FormattedNumber(0, N, Width, false, false, false);
 }
 
-} // end namespace llvm
+} // end namespace wpi_llvm
 
 #endif

--- a/src/main/native/include/llvm/Hashing.h
+++ b/src/main/native/include/llvm/Hashing.h
@@ -53,7 +53,7 @@
 #include <string>
 #include <utility>
 
-namespace llvm {
+namespace wpi_llvm {
 
 /// \brief An opaque object representing a hash code.
 ///
@@ -64,8 +64,8 @@ namespace llvm {
 ///
 /// In order to obtain the hash_code for an object 'x':
 /// \code
-///   using llvm::hash_value;
-///   llvm::hash_code code = hash_value(x);
+///   using wpi_llvm::hash_value;
+///   wpi_llvm::hash_code code = hash_value(x);
 /// \endcode
 class hash_code {
   size_t value;
@@ -311,7 +311,7 @@ struct hash_state {
 
 /// \brief A global, fixed seed-override variable.
 ///
-/// This variable can be set using the \see llvm::set_fixed_execution_seed
+/// This variable can be set using the \see wpi_llvm::set_fixed_execution_seed
 /// function. See that function for details. Do not, under any circumstances,
 /// set or read this variable.
 extern size_t fixed_seed_override;
@@ -370,7 +370,7 @@ get_hashable_data(const T &value) {
 template <typename T>
 typename std::enable_if<!is_hashable_data<T>::value, size_t>::type
 get_hashable_data(const T &value) {
-  using ::llvm::hash_value;
+  using ::wpi_llvm::hash_value;
   return hash_value(value);
 }
 
@@ -476,7 +476,7 @@ hash_combine_range_impl(ValueT *first, ValueT *last) {
 /// a sequence of bytes.
 template <typename InputIteratorT>
 hash_code hash_combine_range(InputIteratorT first, InputIteratorT last) {
-  return ::llvm::hashing::detail::hash_combine_range_impl(first, last);
+  return ::wpi_llvm::hashing::detail::hash_combine_range_impl(first, last);
 }
 
 
@@ -599,7 +599,7 @@ public:
 /// *not* call this routine, they should instead call 'hash_value'.
 template <typename ...Ts> hash_code hash_combine(const Ts &...args) {
   // Recursively hash each argument using a helper class.
-  ::llvm::hashing::detail::hash_combine_recursive_helper helper;
+  ::wpi_llvm::hashing::detail::hash_combine_recursive_helper helper;
   return helper.combine(0, helper.buffer, helper.buffer + 64, args...);
 }
 
@@ -629,14 +629,14 @@ inline hash_code hash_integer_value(uint64_t value) {
 template <typename T>
 typename std::enable_if<is_integral_or_enum<T>::value, hash_code>::type
 hash_value(T value) {
-  return ::llvm::hashing::detail::hash_integer_value(
+  return ::wpi_llvm::hashing::detail::hash_integer_value(
       static_cast<uint64_t>(value));
 }
 
 // Declared and documented above, but defined here so that any of the hashing
 // infrastructure is available.
 template <typename T> hash_code hash_value(const T *ptr) {
-  return ::llvm::hashing::detail::hash_integer_value(
+  return ::wpi_llvm::hashing::detail::hash_integer_value(
     reinterpret_cast<uintptr_t>(ptr));
 }
 
@@ -654,6 +654,6 @@ hash_code hash_value(const std::basic_string<T> &arg) {
   return hash_combine_range(arg.begin(), arg.end());
 }
 
-} // namespace llvm
+} // namespace wpi_llvm
 
 #endif

--- a/src/main/native/include/llvm/IntrusiveRefCntPtr.h
+++ b/src/main/native/include/llvm/IntrusiveRefCntPtr.h
@@ -25,7 +25,7 @@
 #include <cassert>
 #include <cstddef>
 
-namespace llvm {
+namespace wpi_llvm {
 
   template <class T>
   class IntrusiveRefCntPtr;
@@ -89,7 +89,7 @@ namespace llvm {
     static void release(T *obj) { obj->Release(); }
   };
 
-/// \brief A thread-safe version of \c llvm::RefCountedBase.
+/// \brief A thread-safe version of \c wpi_llvm::RefCountedBase.
 ///
 /// A generic base class for objects that wish to have their lifetimes managed
 /// using reference counts. Classes subclass \c ThreadSafeRefCountedBase to
@@ -283,6 +283,6 @@ public:
     }
   };
 
-} // end namespace llvm
+} // end namespace wpi_llvm
 
 #endif // LLVM_ADT_INTRUSIVEREFCNTPTR_H

--- a/src/main/native/include/llvm/MathExtras.h
+++ b/src/main/native/include/llvm/MathExtras.h
@@ -27,7 +27,7 @@
 #include <intrin.h>
 #endif
 
-namespace llvm {
+namespace wpi_llvm {
 /// \brief The behavior an operation has on an input of 0.
 enum ZeroBehavior {
   /// \brief The returned value is undefined.
@@ -648,6 +648,6 @@ SaturatingMultiplyAdd(T X, T Y, T A, bool *ResultOverflowed = nullptr) {
   return SaturatingAdd(A, Product, &Overflowed);
 }
 
-} // namespace llvm
+} // namespace wpi_llvm
 
 #endif

--- a/src/main/native/include/llvm/None.h
+++ b/src/main/native/include/llvm/None.h
@@ -16,7 +16,7 @@
 #ifndef LLVM_ADT_NONE_H
 #define LLVM_ADT_NONE_H
 
-namespace llvm {
+namespace wpi_llvm {
 /// \brief A simple null object to allow implicit construction of Optional<T>
 /// and similar types without having to spell out the specialization's name.
 enum class NoneType { None };

--- a/src/main/native/include/llvm/Optional.h
+++ b/src/main/native/include/llvm/Optional.h
@@ -23,7 +23,7 @@
 #include <new>
 #include <utility>
 
-namespace llvm {
+namespace wpi_llvm {
 
 template<typename T>
 class Optional {

--- a/src/main/native/include/llvm/Path.h
+++ b/src/main/native/include/llvm/Path.h
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file declares the llvm::sys::path namespace. It is designed after
+// This file declares the wpi_llvm::sys::path namespace. It is designed after
 // TR2/boost filesystem (v3), but modified to remove exception handling and the
 // path class.
 //
@@ -21,7 +21,7 @@
 
 #include <stdint.h>
 
-namespace llvm {
+namespace wpi_llvm {
 namespace sys {
 namespace path {
 
@@ -452,6 +452,6 @@ bool remove_dots(SmallVectorImpl<char> &path, bool remove_dot_dot = false);
 
 } // end namespace path
 } // end namespace sys
-} // end namespace llvm
+} // end namespace wpi_llvm
 
 #endif

--- a/src/main/native/include/llvm/PointerLikeTypeTraits.h
+++ b/src/main/native/include/llvm/PointerLikeTypeTraits.h
@@ -18,7 +18,7 @@
 #include "llvm/AlignOf.h"
 #include <cstdint>
 
-namespace llvm {
+namespace wpi_llvm {
 
 /// A traits type that is used to handle pointer types and things that are just
 /// wrappers for pointers as a uniform entity.
@@ -89,6 +89,6 @@ public:
   enum { NumLowBitsAvailable = 0 };
 };
 
-} // end namespace llvm
+} // end namespace wpi_llvm
 
 #endif

--- a/src/main/native/include/llvm/STLExtras.h
+++ b/src/main/native/include/llvm/STLExtras.h
@@ -29,7 +29,7 @@
 #include "llvm/iterator_range.h"
 #include "llvm/Compiler.h"
 
-namespace llvm {
+namespace wpi_llvm {
 
 //===----------------------------------------------------------------------===//
 //     Extra additions to <functional>
@@ -229,10 +229,10 @@ template <typename ContainerTy>
 auto reverse(
     ContainerTy &&C,
     typename std::enable_if<!has_rbegin<ContainerTy>::value>::type * = nullptr)
-    -> decltype(make_range(llvm::make_reverse_iterator(std::end(C)),
-                           llvm::make_reverse_iterator(std::begin(C)))) {
-  return make_range(llvm::make_reverse_iterator(std::end(C)),
-                    llvm::make_reverse_iterator(std::begin(C)));
+    -> decltype(make_range(wpi_llvm::make_reverse_iterator(std::end(C)),
+                           wpi_llvm::make_reverse_iterator(std::begin(C)))) {
+  return make_range(wpi_llvm::make_reverse_iterator(std::end(C)),
+                    wpi_llvm::make_reverse_iterator(std::begin(C)));
 }
 
 //===----------------------------------------------------------------------===//

--- a/src/main/native/include/llvm/SmallPtrSet.h
+++ b/src/main/native/include/llvm/SmallPtrSet.h
@@ -25,7 +25,7 @@
 #include <iterator>
 #include <utility>
 
-namespace llvm {
+namespace wpi_llvm {
 
 class SmallPtrSetIteratorImpl;
 
@@ -398,7 +398,7 @@ public:
 namespace std {
   /// Implement std::swap in terms of SmallPtrSet swap.
   template<class T, unsigned N>
-  inline void swap(llvm::SmallPtrSet<T, N> &LHS, llvm::SmallPtrSet<T, N> &RHS) {
+  inline void swap(wpi_llvm::SmallPtrSet<T, N> &LHS, wpi_llvm::SmallPtrSet<T, N> &RHS) {
     LHS.swap(RHS);
   }
 }

--- a/src/main/native/include/llvm/SmallSet.h
+++ b/src/main/native/include/llvm/SmallSet.h
@@ -19,7 +19,7 @@
 #include "llvm/SmallVector.h"
 #include <set>
 
-namespace llvm {
+namespace wpi_llvm {
 
 /// SmallSet - This maintains a set of unique values, optimizing for the case
 /// when the set is small (less than N).  In this case, the set can be
@@ -131,6 +131,6 @@ private:
 template <typename PointeeType, unsigned N>
 class SmallSet<PointeeType*, N> : public SmallPtrSet<PointeeType*, N> {};
 
-} // end namespace llvm
+} // end namespace wpi_llvm
 
 #endif

--- a/src/main/native/include/llvm/SmallString.h
+++ b/src/main/native/include/llvm/SmallString.h
@@ -17,7 +17,7 @@
 #include "llvm/SmallVector.h"
 #include "llvm/StringRef.h"
 
-namespace llvm {
+namespace wpi_llvm {
 
 /// SmallString - A SmallString is just a SmallVector with methods and accessors
 /// that make it work better as a string (e.g. operator+ etc).

--- a/src/main/native/include/llvm/SmallVector.h
+++ b/src/main/native/include/llvm/SmallVector.h
@@ -28,7 +28,7 @@
 #include <iterator>
 #include <memory>
 
-namespace llvm {
+namespace wpi_llvm {
 
 /// This is all the non-templated stuff common to all SmallVectors.
 class SmallVectorBase {
@@ -70,7 +70,7 @@ private:
   // Allocate raw space for N elements of type T.  If T has a ctor or dtor, we
   // don't want it to be automatically run, so we need to represent the space as
   // something else.  Use an array of char of sufficient alignment.
-  typedef llvm::AlignedCharArrayUnion<T> U;
+  typedef wpi_llvm::AlignedCharArrayUnion<T> U;
   U FirstEl;
   // Space after 'FirstEl' is clobbered, do not add any instance vars after it.
 
@@ -849,7 +849,7 @@ public:
   }
 
   template <typename RangeTy>
-  explicit SmallVector(const llvm::iterator_range<RangeTy> R)
+  explicit SmallVector(const wpi_llvm::iterator_range<RangeTy> R)
       : SmallVectorImpl<T>(N) {
     this->append(R.begin(), R.end());
   }
@@ -905,14 +905,14 @@ namespace std {
   /// Implement std::swap in terms of SmallVector swap.
   template<typename T>
   inline void
-  swap(llvm::SmallVectorImpl<T> &LHS, llvm::SmallVectorImpl<T> &RHS) {
+  swap(wpi_llvm::SmallVectorImpl<T> &LHS, wpi_llvm::SmallVectorImpl<T> &RHS) {
     LHS.swap(RHS);
   }
 
   /// Implement std::swap in terms of SmallVector swap.
   template<typename T, unsigned N>
   inline void
-  swap(llvm::SmallVector<T, N> &LHS, llvm::SmallVector<T, N> &RHS) {
+  swap(wpi_llvm::SmallVector<T, N> &LHS, wpi_llvm::SmallVector<T, N> &RHS) {
     LHS.swap(RHS);
   }
 }

--- a/src/main/native/include/llvm/StringExtras.h
+++ b/src/main/native/include/llvm/StringExtras.h
@@ -18,7 +18,7 @@
 #include <cstdint>
 #include <iterator>
 
-namespace llvm {
+namespace wpi_llvm {
 template<typename T> class SmallVectorImpl;
 
 /// hexdigit - Return the hexadecimal character for the

--- a/src/main/native/include/llvm/StringMap.h
+++ b/src/main/native/include/llvm/StringMap.h
@@ -22,7 +22,7 @@
 #include <cstring>
 #include <utility>
 
-namespace llvm {
+namespace wpi_llvm {
   template<typename ValueT>
   class StringMapConstIterator;
   template<typename ValueT>
@@ -558,6 +558,6 @@ inline bool operator>=(const StringMap<ValueTy>& lhs,
   return !(lhs < rhs);
 }
 
-} // namespace llvm
+} // namespace wpi_llvm
 
 #endif

--- a/src/main/native/include/llvm/StringRef.h
+++ b/src/main/native/include/llvm/StringRef.h
@@ -20,7 +20,7 @@
 #include <string>
 #include <utility>
 
-namespace llvm {
+namespace wpi_llvm {
   template <typename T>
   class SmallVectorImpl;
   class hash_code;
@@ -140,7 +140,7 @@ namespace llvm {
 
     /// c_str - Get a null terminated pointer to the start of the string
     /// If string is not null terminated, use buffer to store new string
-    const char *c_str(llvm::SmallVectorImpl<char>& buf) const;
+    const char *c_str(wpi_llvm::SmallVectorImpl<char>& buf) const;
 
     /// empty - Check if the string is empty.
     bool empty() const { return size() == 0; }
@@ -621,6 +621,6 @@ namespace llvm {
   // StringRefs can be treated like a POD type.
   template <typename T> struct isPodLike;
   template <> struct isPodLike<StringRef> { static const bool value = true; };
-} // namespace llvm
+} // namespace wpi_llvm
 
 #endif

--- a/src/main/native/include/llvm/Twine.h
+++ b/src/main/native/include/llvm/Twine.h
@@ -17,7 +17,7 @@
 
 #include <stdint.h>
 
-namespace llvm {
+namespace wpi_llvm {
   class raw_ostream;
 
   /// Twine - A lightweight data structure for efficiently representing the

--- a/src/main/native/include/llvm/WindowsError.h
+++ b/src/main/native/include/llvm/WindowsError.h
@@ -12,7 +12,7 @@
 
 #include <system_error>
 
-namespace llvm {
+namespace wpi_llvm {
 std::error_code mapWindowsError(unsigned EV);
 }
 

--- a/src/main/native/include/llvm/iterator_range.h
+++ b/src/main/native/include/llvm/iterator_range.h
@@ -22,7 +22,7 @@
 #include <utility>
 #include <iterator>
 
-namespace llvm {
+namespace wpi_llvm {
 
 /// \brief A range adaptor for a pair of iterators.
 ///

--- a/src/main/native/include/llvm/raw_os_ostream.h
+++ b/src/main/native/include/llvm/raw_os_ostream.h
@@ -17,7 +17,7 @@
 #include "llvm/raw_ostream.h"
 #include <iosfwd>
 
-namespace llvm {
+namespace wpi_llvm {
 
 /// raw_os_ostream - A raw_ostream that writes to an std::ostream.  This is a
 /// simple adaptor class.  It does not check for output errors; clients should

--- a/src/main/native/include/llvm/raw_ostream.h
+++ b/src/main/native/include/llvm/raw_ostream.h
@@ -20,7 +20,7 @@
 #include <cstdint>
 #include <system_error>
 
-namespace llvm {
+namespace wpi_llvm {
 class format_object_base;
 class FormattedString;
 class FormattedNumber;
@@ -179,7 +179,7 @@ public:
     return write(Str.data(), Str.length());
   }
 
-  raw_ostream &operator<<(const llvm::SmallVectorImpl<char> &Str) {
+  raw_ostream &operator<<(const wpi_llvm::SmallVectorImpl<char> &Str) {
     return write(Str.data(), Str.size());
   }
 

--- a/src/main/native/include/llvm/type_traits.h
+++ b/src/main/native/include/llvm/type_traits.h
@@ -19,7 +19,7 @@
 
 #include "llvm/Compiler.h"
 
-namespace llvm {
+namespace wpi_llvm {
 
 /// isPodLike - This is a type trait that is used to determine whether a given
 /// type can be copied around with memcpy instead of running ctors etc.
@@ -90,6 +90,6 @@ struct add_const_past_pointer<
   typedef const typename std::remove_pointer<T>::type *type;
 };
 
-} // namespace llvm
+} // namespace wpi_llvm
 
 #endif

--- a/src/main/native/include/support/Base64.h
+++ b/src/main/native/include/support/Base64.h
@@ -13,27 +13,27 @@
 
 #include "llvm/StringRef.h"
 
-namespace llvm {
+namespace wpi_llvm {
 template <typename T>
 class SmallVectorImpl;
 class raw_ostream;
-}  // namespace llvm
+}  // namespace wpi_llvm
 
 namespace wpi {
 
-size_t Base64Decode(llvm::raw_ostream& os, llvm::StringRef encoded);
+size_t Base64Decode(wpi_llvm::raw_ostream& os, wpi_llvm::StringRef encoded);
 
-size_t Base64Decode(llvm::StringRef encoded, std::string* plain);
+size_t Base64Decode(wpi_llvm::StringRef encoded, std::string* plain);
 
-llvm::StringRef Base64Decode(llvm::StringRef encoded, size_t* num_read,
-                             llvm::SmallVectorImpl<char>& buf);
+wpi_llvm::StringRef Base64Decode(wpi_llvm::StringRef encoded, size_t* num_read,
+                             wpi_llvm::SmallVectorImpl<char>& buf);
 
-void Base64Encode(llvm::raw_ostream& os, llvm::StringRef plain);
+void Base64Encode(wpi_llvm::raw_ostream& os, wpi_llvm::StringRef plain);
 
-void Base64Encode(llvm::StringRef plain, std::string* encoded);
+void Base64Encode(wpi_llvm::StringRef plain, std::string* encoded);
 
-llvm::StringRef Base64Encode(llvm::StringRef plain,
-                             llvm::SmallVectorImpl<char>& buf);
+wpi_llvm::StringRef Base64Encode(wpi_llvm::StringRef plain,
+                             wpi_llvm::SmallVectorImpl<char>& buf);
 
 }  // namespace wpi
 

--- a/src/main/native/include/support/HttpUtil.h
+++ b/src/main/native/include/support/HttpUtil.h
@@ -30,15 +30,15 @@ namespace wpi {
 // @param buf Buffer for output
 // @param error Set to true if an error occurred
 // @return Escaped string
-llvm::StringRef UnescapeURI(const llvm::Twine& str,
-                            llvm::SmallVectorImpl<char>& buf, bool* error);
+wpi_llvm::StringRef UnescapeURI(const wpi_llvm::Twine& str,
+                            wpi_llvm::SmallVectorImpl<char>& buf, bool* error);
 
 // Escape a string with %xx-encoding.
 // @param buf Buffer for output
 // @param spacePlus If true, encodes spaces to '+' rather than "%20"
 // @return Escaped string
-llvm::StringRef EscapeURI(const llvm::Twine& str,
-                          llvm::SmallVectorImpl<char>& buf,
+wpi_llvm::StringRef EscapeURI(const wpi_llvm::Twine& str,
+                          wpi_llvm::SmallVectorImpl<char>& buf,
                           bool spacePlus = true);
 
 // Parse a set of HTTP headers.  Saves just the Content-Type and Content-Length
@@ -48,8 +48,8 @@ llvm::StringRef EscapeURI(const llvm::Twine& str,
 // @param contentLength If not null, Content-Length contents are saved here.
 // @return False if error occurred in input stream
 bool ParseHttpHeaders(wpi::raw_istream& is,
-                      llvm::SmallVectorImpl<char>* contentType,
-                      llvm::SmallVectorImpl<char>* contentLength);
+                      wpi_llvm::SmallVectorImpl<char>* contentType,
+                      wpi_llvm::SmallVectorImpl<char>* contentLength);
 
 // Look for a MIME multi-part boundary.  On return, the input stream will
 // be located at the character following the boundary (usually "\r\n").
@@ -58,13 +58,13 @@ bool ParseHttpHeaders(wpi::raw_istream& is,
 // @param saveBuf If not null, all scanned characters up to but not including
 //     the boundary are saved to this string
 // @return False if error occurred on input stream, true if boundary found.
-bool FindMultipartBoundary(wpi::raw_istream& is, llvm::StringRef boundary,
+bool FindMultipartBoundary(wpi::raw_istream& is, wpi_llvm::StringRef boundary,
                            std::string* saveBuf);
 
 class HttpLocation {
  public:
   HttpLocation() = default;
-  HttpLocation(const llvm::Twine& url_, bool* error, std::string* errorMsg);
+  HttpLocation(const wpi_llvm::Twine& url_, bool* error, std::string* errorMsg);
 
   std::string url;       // retain copy
   std::string user;      // unescaped
@@ -89,38 +89,38 @@ class HttpRequest {
   template <typename T>
   HttpRequest(const HttpLocation& loc, const T& extraParams);
 
-  HttpRequest(const HttpLocation& loc, llvm::StringRef path_)
+  HttpRequest(const HttpLocation& loc, wpi_llvm::StringRef path_)
       : host{loc.host}, port{loc.port}, path{path_} {
     SetAuth(loc);
   }
 
   template <typename T>
-  HttpRequest(const HttpLocation& loc, llvm::StringRef path_, const T& params)
+  HttpRequest(const HttpLocation& loc, wpi_llvm::StringRef path_, const T& params)
       : host{loc.host}, port{loc.port} {
     SetPath(path_, params);
     SetAuth(loc);
   }
 
-  llvm::SmallString<128> host;
+  wpi_llvm::SmallString<128> host;
   int port;
   std::string auth;
-  llvm::SmallString<128> path;
+  wpi_llvm::SmallString<128> path;
 
  private:
   void SetAuth(const HttpLocation& loc);
   template <typename T>
-  void SetPath(llvm::StringRef path_, const T& params);
+  void SetPath(wpi_llvm::StringRef path_, const T& params);
 
   template <typename T>
-  static llvm::StringRef GetFirst(const T& elem) {
+  static wpi_llvm::StringRef GetFirst(const T& elem) {
     return elem.first;
   }
   template <typename T>
-  static llvm::StringRef GetFirst(const llvm::StringMapEntry<T>& elem) {
+  static wpi_llvm::StringRef GetFirst(const wpi_llvm::StringMapEntry<T>& elem) {
     return elem.getKey();
   }
   template <typename T>
-  static llvm::StringRef GetSecond(const T& elem) {
+  static wpi_llvm::StringRef GetSecond(const T& elem) {
     return elem.second;
   }
 };
@@ -137,8 +137,8 @@ class HttpConnection {
   wpi::raw_socket_ostream os;
 
   // Valid after Handshake() is successful
-  llvm::SmallString<64> contentType;
-  llvm::SmallString<64> contentLength;
+  wpi_llvm::SmallString<64> contentType;
+  wpi_llvm::SmallString<64> contentLength;
 
   explicit operator bool() const { return stream && !is.has_error(); }
 };

--- a/src/main/native/include/support/HttpUtil.inl
+++ b/src/main/native/include/support/HttpUtil.inl
@@ -13,7 +13,7 @@ namespace wpi {
 template <typename T>
 HttpRequest::HttpRequest(const HttpLocation& loc, const T& extraParams)
     : host{loc.host}, port{loc.port} {
-  llvm::StringMap<llvm::StringRef> params;
+  wpi_llvm::StringMap<wpi_llvm::StringRef> params;
   for (const auto& p : loc.params)
     params.insert(std::make_pair(GetFirst(p), GetSecond(p)));
   for (const auto& p : extraParams)
@@ -23,9 +23,9 @@ HttpRequest::HttpRequest(const HttpLocation& loc, const T& extraParams)
 }
 
 template <typename T>
-void HttpRequest::SetPath(llvm::StringRef path_, const T& params) {
+void HttpRequest::SetPath(wpi_llvm::StringRef path_, const T& params) {
   // Build location including query string
-  llvm::raw_svector_ostream pathOs{path};
+  wpi_llvm::raw_svector_ostream pathOs{path};
   pathOs << path_;
   bool first = true;
   for (const auto& param : params) {
@@ -35,7 +35,7 @@ void HttpRequest::SetPath(llvm::StringRef path_, const T& params) {
     } else {
       pathOs << '&';
     }
-    llvm::SmallString<64> escapeBuf;
+    wpi_llvm::SmallString<64> escapeBuf;
     pathOs << EscapeURI(GetFirst(param), escapeBuf);
     if (!GetSecond(param).empty()) {
       pathOs << '=' << EscapeURI(GetSecond(param), escapeBuf);

--- a/src/main/native/include/support/Logger.h
+++ b/src/main/native/include/support/Logger.h
@@ -60,8 +60,8 @@ class Logger {
   do {                                                                 \
     ::wpi::Logger& WPI_logger_ = logger_inst;                          \
     if (WPI_logger_.min_level() <= level && WPI_logger_.HasLogger()) { \
-      llvm::SmallString<128> log_buf_;                                 \
-      llvm::raw_svector_ostream log_os_{log_buf_};                     \
+      wpi_llvm::SmallString<128> log_buf_;                                 \
+      wpi_llvm::raw_svector_ostream log_os_{log_buf_};                     \
       log_os_ << x;                                                    \
       WPI_logger_.Log(level, __FILE__, __LINE__, log_buf_.c_str());    \
     }                                                                  \

--- a/src/main/native/include/support/hostname.h
+++ b/src/main/native/include/support/hostname.h
@@ -12,14 +12,14 @@
 
 #include "llvm/StringRef.h"
 
-namespace llvm {
+namespace wpi_llvm {
 template <typename T>
 class SmallVectorImpl;
-}  // namespace llvm
+}  // namespace wpi_llvm
 
 namespace wpi {
 std::string GetHostname();
-llvm::StringRef GetHostname(llvm::SmallVectorImpl<char>& name);
+wpi_llvm::StringRef GetHostname(wpi_llvm::SmallVectorImpl<char>& name);
 }  // namespace wpi
 
 #endif  // WPIUTIL_SUPPORT_HOSTNAME_H_

--- a/src/main/native/include/support/json.h
+++ b/src/main/native/include/support/json.h
@@ -476,7 +476,7 @@ template<>
 struct external_constructor<value_t::string>
 {
     template<typename BasicJsonType>
-    static void construct(BasicJsonType& j, llvm::StringRef s)
+    static void construct(BasicJsonType& j, wpi_llvm::StringRef s)
     {
         j.m_type = value_t::string;
         j.m_value = s;
@@ -532,7 +532,7 @@ struct external_constructor<value_t::array>
     }
 
     template<typename BasicJsonType, typename T>
-    static void construct(BasicJsonType& j, llvm::ArrayRef<T> arr)
+    static void construct(BasicJsonType& j, wpi_llvm::ArrayRef<T> arr)
     {
         using std::begin;
         using std::end;
@@ -636,7 +636,7 @@ template<class RealType, class CompatibleObjectType>
 struct is_compatible_object_type_impl<true, RealType, CompatibleObjectType>
 {
     static constexpr auto value =
-        std::is_constructible<llvm::StringRef,
+        std::is_constructible<wpi_llvm::StringRef,
         typename CompatibleObjectType::key_type>::value &&
         std::is_constructible<typename RealType::mapped_type,
         typename CompatibleObjectType::mapped_type>::value;
@@ -666,7 +666,7 @@ struct is_compatible_array_type
     static auto constexpr value =
         conjunction<negation<std::is_same<void, CompatibleArrayType>>,
         negation<is_compatible_object_type<BasicJsonType, CompatibleArrayType>>,
-        negation<std::is_constructible<llvm::StringRef, CompatibleArrayType>>,
+        negation<std::is_constructible<wpi_llvm::StringRef, CompatibleArrayType>>,
         negation<is_json_nested_type<BasicJsonType, CompatibleArrayType>>,
         has_value_type<CompatibleArrayType>,
         has_iterator<CompatibleArrayType>>::value;
@@ -712,7 +712,7 @@ void to_json(BasicJsonType& j, T b) noexcept
 }
 
 template<typename BasicJsonType, typename CompatibleString,
-         enable_if_t<std::is_constructible<llvm::StringRef,
+         enable_if_t<std::is_constructible<wpi_llvm::StringRef,
                      CompatibleString>::value, int> = 0>
 inline
 void to_json(BasicJsonType& j, const CompatibleString& s)
@@ -766,7 +766,7 @@ void to_json(BasicJsonType& j, const std::vector<bool>& e)
 
 template<typename BasicJsonType, typename T>
 inline
-void to_json(BasicJsonType& j, llvm::ArrayRef<T> arr)
+void to_json(BasicJsonType& j, wpi_llvm::ArrayRef<T> arr)
 {
     external_constructor<value_t::array>::construct(j, arr);
 }
@@ -795,7 +795,7 @@ void to_json(BasicJsonType& j, const  CompatibleObjectType& arr)
 
 template <typename BasicJsonType, typename T, std::size_t N,
           enable_if_t<!std::is_constructible<
-                          llvm::StringRef, T (&)[N]>::value,
+                          wpi_llvm::StringRef, T (&)[N]>::value,
                       int> = 0>
 inline
 void to_json(BasicJsonType& j, T (&arr)[N])
@@ -804,7 +804,7 @@ void to_json(BasicJsonType& j, T (&arr)[N])
 }
 
 template <typename BasicJsonType, typename CompatibleString, typename T,
-          enable_if_t<std::is_constructible<llvm::StringRef,
+          enable_if_t<std::is_constructible<wpi_llvm::StringRef,
                       CompatibleString>::value, int> = 0>
 inline
 void to_json(BasicJsonType& j, std::pair<CompatibleString, T> const& p)
@@ -1048,7 +1048,7 @@ void from_json(const BasicJsonType& j, ArithmeticType& val)
 }
 
 template <typename BasicJsonType, typename CompatibleString, typename T,
-          enable_if_t<std::is_constructible<llvm::StringRef,
+          enable_if_t<std::is_constructible<wpi_llvm::StringRef,
                       CompatibleString>::value, int> = 0>
 void from_json(const BasicJsonType& j, std::pair<CompatibleString, T>& p)
 {
@@ -1363,7 +1363,7 @@ class json
     7159](http://rfc7159.net/rfc7159), because any order implements the
     specified "unordered" nature of JSON objects.
     */
-    using object_t = llvm::StringMap<json>;
+    using object_t = wpi_llvm::StringMap<json>;
 
     /*!
     @brief a type for an array
@@ -1754,7 +1754,7 @@ class json
         json_value(value_t t);
 
         /// constructor for strings
-        json_value(llvm::StringRef value);
+        json_value(wpi_llvm::StringRef value);
         json_value(const std::string& value);
 
         /// constructor for objects
@@ -2477,7 +2477,7 @@ class json
 
     @since version 1.0.0; indentaction character added in version 3.0.0
     */
-    void dump(llvm::raw_ostream& os, int indent = -1) const;
+    void dump(wpi_llvm::raw_ostream& os, int indent = -1) const;
 
     /*!
     @brief return the type of the JSON value (explicit)
@@ -3354,7 +3354,7 @@ class json
 
     @complexity Logarithmic in the size of the container.
 
-    @sa @ref operator[](llvm::StringRef) for unchecked
+    @sa @ref operator[](wpi_llvm::StringRef) for unchecked
     access by reference
     @sa @ref value() for access by value with a default value
 
@@ -3364,7 +3364,7 @@ class json
     written using `at()`. It also demonstrates the different exceptions that
     can be thrown.,at__object_t_key_type}
     */
-    reference at(llvm::StringRef key);
+    reference at(wpi_llvm::StringRef key);
 
     /*!
     @brief access specified object element with bounds checking
@@ -3386,7 +3386,7 @@ class json
 
     @complexity Logarithmic in the size of the container.
 
-    @sa @ref operator[](llvm::StringRef) for unchecked
+    @sa @ref operator[](wpi_llvm::StringRef) for unchecked
     access by reference
     @sa @ref value() for access by value with a default value
 
@@ -3396,7 +3396,7 @@ class json
     `at()`. It also demonstrates the different exceptions that can be thrown.,
     at__object_t_key_type_const}
     */
-    const_reference at(llvm::StringRef key) const;
+    const_reference at(wpi_llvm::StringRef key) const;
 
     /*!
     @brief access specified array element
@@ -3467,13 +3467,13 @@ class json
     @liveexample{The example below shows how object elements can be read and
     written using the `[]` operator.,operatorarray__key_type}
 
-    @sa @ref at(llvm::StringRef) for access by reference
+    @sa @ref at(wpi_llvm::StringRef) for access by reference
     with range checking
     @sa @ref value() for access by value with a default value
 
     @since version 1.0.0
     */
-    reference operator[](llvm::StringRef key);
+    reference operator[](wpi_llvm::StringRef key);
 
     /*!
     @brief read-only access specified object element
@@ -3499,13 +3499,13 @@ class json
     @liveexample{The example below shows how object elements can be read using
     the `[]` operator.,operatorarray__key_type_const}
 
-    @sa @ref at(llvm::StringRef) for access by reference
+    @sa @ref at(wpi_llvm::StringRef) for access by reference
     with range checking
     @sa @ref value() for access by value with a default value
 
     @since version 1.0.0
     */
-    const_reference operator[](llvm::StringRef key) const;
+    const_reference operator[](wpi_llvm::StringRef key) const;
 
     /*!
     @brief access specified object element
@@ -3605,7 +3605,7 @@ class json
     template<typename T>
     reference operator[](T* key)
     {
-        return this->operator[](llvm::StringRef(key));
+        return this->operator[](wpi_llvm::StringRef(key));
     }
 
     /*!
@@ -3641,7 +3641,7 @@ class json
     template<typename T>
     const_reference operator[](T* key) const
     {
-        return this->operator[](llvm::StringRef(key));
+        return this->operator[](wpi_llvm::StringRef(key));
     }
 
     /*!
@@ -3659,10 +3659,10 @@ class json
     }
     @endcode
 
-    @note Unlike @ref at(llvm::StringRef), this function
+    @note Unlike @ref at(wpi_llvm::StringRef), this function
     does not throw if the given key @a key was not found.
 
-    @note Unlike @ref operator[](llvm::StringRef key), this
+    @note Unlike @ref operator[](wpi_llvm::StringRef key), this
     function does not implicitly add an element to the position defined by @a
     key. This function is furthermore also applicable to const objects.
 
@@ -3685,16 +3685,16 @@ class json
     @liveexample{The example below shows how object elements can be queried
     with a default value.,json__value}
 
-    @sa @ref at(llvm::StringRef) for access by reference
+    @sa @ref at(wpi_llvm::StringRef) for access by reference
     with range checking
-    @sa @ref operator[](llvm::StringRef) for unchecked
+    @sa @ref operator[](wpi_llvm::StringRef) for unchecked
     access by reference
 
     @since version 1.0.0
     */
     template<class ValueType, typename std::enable_if<
                  std::is_convertible<json, ValueType>::value, int>::type = 0>
-    ValueType value(llvm::StringRef key, ValueType default_value) const
+    ValueType value(wpi_llvm::StringRef key, ValueType default_value) const
     {
         // at only works for objects
         if (is_object())
@@ -3716,9 +3716,9 @@ class json
 
     /*!
     @brief overload for a default value of type const char*
-    @copydoc json::value(llvm::StringRef, ValueType) const
+    @copydoc json::value(wpi_llvm::StringRef, ValueType) const
     */
-    std::string value(llvm::StringRef key, const char* default_value) const
+    std::string value(wpi_llvm::StringRef key, const char* default_value) const
     {
         return value(key, std::string(default_value));
     }
@@ -3907,7 +3907,7 @@ class json
 
     @sa @ref erase(IteratorType, IteratorType) -- removes the elements in
     the given range
-    @sa @ref erase(llvm::StringRef) -- removes the element
+    @sa @ref erase(wpi_llvm::StringRef) -- removes the element
     from an object at the given key
     @sa @ref erase(const size_type) -- removes the element from an array at
     the given index
@@ -4010,7 +4010,7 @@ class json
     types.,erase__IteratorType_IteratorType}
 
     @sa @ref erase(IteratorType) -- removes the element at a given position
-    @sa @ref erase(llvm::StringRef) -- removes the element
+    @sa @ref erase(wpi_llvm::StringRef) -- removes the element
     from an object at the given key
     @sa @ref erase(const size_type) -- removes the element from an array at
     the given index
@@ -4098,7 +4098,7 @@ class json
 
     @since version 1.0.0
     */
-    size_type erase(llvm::StringRef key);
+    size_type erase(wpi_llvm::StringRef key);
 
     /*!
     @brief remove element from a JSON array given an index
@@ -4119,7 +4119,7 @@ class json
     @sa @ref erase(IteratorType) -- removes the element at a given position
     @sa @ref erase(IteratorType, IteratorType) -- removes the elements in
     the given range
-    @sa @ref erase(llvm::StringRef) -- removes the element
+    @sa @ref erase(wpi_llvm::StringRef) -- removes the element
     from an object at the given key
 
     @since version 1.0.0
@@ -4158,13 +4158,13 @@ class json
 
     @since version 1.0.0
     */
-    iterator find(llvm::StringRef key);
+    iterator find(wpi_llvm::StringRef key);
 
     /*!
     @brief find an element in a JSON object
-    @copydoc find(llvm::StringRef)
+    @copydoc find(wpi_llvm::StringRef)
     */
-    const_iterator find(llvm::StringRef key) const;
+    const_iterator find(wpi_llvm::StringRef key) const;
 
     /*!
     @brief returns the number of occurrences of a key in a JSON object
@@ -4187,7 +4187,7 @@ class json
 
     @since version 1.0.0
     */
-    size_type count(llvm::StringRef key) const
+    size_type count(wpi_llvm::StringRef key) const
     {
         // return 0 for all nonobject types
         return is_object() ? m_value.object->count(key) : 0;
@@ -4605,13 +4605,13 @@ class json
 
     @since version 1.0.0
     */
-    void push_back(const std::pair<llvm::StringRef, json>& val);
+    void push_back(const std::pair<wpi_llvm::StringRef, json>& val);
 
     /*!
     @brief add an object to an object
     @copydoc push_back(const typename object_t::value_type&)
     */
-    reference operator+=(const std::pair<llvm::StringRef, json>& val)
+    reference operator+=(const std::pair<wpi_llvm::StringRef, json>& val)
     {
         push_back(val);
         return *this;
@@ -4724,7 +4724,7 @@ class json
     @since version 2.0.8
     */
     template<class... Args>
-    std::pair<iterator, bool> emplace(llvm::StringRef key, Args&& ... args)
+    std::pair<iterator, bool> emplace(wpi_llvm::StringRef key, Args&& ... args)
     {
         // emplace only works for null objects or arrays
         if (!(is_null() || is_object()))
@@ -5342,7 +5342,7 @@ class json
 
     @since version 1.0.0; indentaction character added in version 3.0.0
     */
-    friend llvm::raw_ostream& operator<<(llvm::raw_ostream& o, const json& j);
+    friend wpi_llvm::raw_ostream& operator<<(wpi_llvm::raw_ostream& o, const json& j);
 
     /// @}
 
@@ -5385,7 +5385,7 @@ class json
 
     @since version 1.0.0 (originally for std::string)
     */
-    static json parse(llvm::StringRef s,
+    static json parse(wpi_llvm::StringRef s,
                             const parser_callback_t cb = nullptr);
 
     /*!
@@ -5571,7 +5571,7 @@ class json
             return lhs.m_it - rhs.m_it;
         }
 
-        friend llvm::raw_ostream& operator<<(llvm::raw_ostream& os, primitive_iterator_t it)
+        friend wpi_llvm::raw_ostream& operator<<(wpi_llvm::raw_ostream& os, primitive_iterator_t it)
         {
             return os << it.m_it;
         }
@@ -6327,7 +6327,7 @@ class json
         @brief  return the key of an object iterator
         @pre The iterator is initialized; i.e. `m_object != nullptr`.
         */
-        llvm::StringRef key() const
+        wpi_llvm::StringRef key() const
         {
             assert(m_object != nullptr);
 
@@ -6445,8 +6445,8 @@ class json
 
     @since version 2.0.9
     */
-    static void to_cbor(llvm::raw_ostream& os, const json& j);
-    static llvm::StringRef to_cbor(const json& j, llvm::SmallVectorImpl<char> buf);
+    static void to_cbor(wpi_llvm::raw_ostream& os, const json& j);
+    static wpi_llvm::StringRef to_cbor(const json& j, wpi_llvm::SmallVectorImpl<char> buf);
     static std::string to_cbor(const json& j);
 
     /*!
@@ -6523,8 +6523,8 @@ class json
 
     @since version 2.0.9
     */
-    static void to_msgpack(llvm::raw_ostream& os, const json& j);
-    static llvm::StringRef to_msgpack(const json& j, llvm::SmallVectorImpl<char> buf);
+    static void to_msgpack(wpi_llvm::raw_ostream& os, const json& j);
+    static wpi_llvm::StringRef to_msgpack(const json& j, wpi_llvm::SmallVectorImpl<char> buf);
     static std::string to_msgpack(const json& j);
 
     /*!
@@ -6614,7 +6614,7 @@ class json
     @since version 2.0.9, parameter @a start_index since 2.1.1
     */
     static json from_cbor(wpi::raw_istream& is);
-    static json from_cbor(llvm::StringRef s);
+    static json from_cbor(wpi_llvm::StringRef s);
 
     /*!
     @brief create a JSON value from a byte vector in MessagePack format
@@ -6683,7 +6683,7 @@ class json
     @since version 2.0.9, parameter @a start_index since 2.1.1
     */
     static json from_msgpack(wpi::raw_istream& is);
-    static json from_msgpack(llvm::StringRef s);
+    static json from_msgpack(wpi_llvm::StringRef s);
 
     /// @}
 
@@ -6937,7 +6937,7 @@ class json
 
     Uses a JSON pointer to retrieve a reference to the respective JSON value.
     No bound checking is performed. Similar to @ref operator[](
-    llvm::StringRef), `null` values are created in arrays and objects if
+    wpi_llvm::StringRef), `null` values are created in arrays and objects if
     necessary.
 
     In particular:
@@ -7214,7 +7214,7 @@ if no parse error occurred.
 */
 inline wpi::json operator "" _json(const char* s, std::size_t n)
 {
-    return wpi::json::parse(llvm::StringRef(s, n));
+    return wpi::json::parse(wpi_llvm::StringRef(s, n));
 }
 
 /*!

--- a/src/main/native/include/support/leb128.h
+++ b/src/main/native/include/support/leb128.h
@@ -17,7 +17,7 @@ namespace wpi {
 class raw_istream;
 
 uint64_t SizeUleb128(uint64_t val);
-uint64_t WriteUleb128(llvm::SmallVectorImpl<char>& dest, uint64_t val);
+uint64_t WriteUleb128(wpi_llvm::SmallVectorImpl<char>& dest, uint64_t val);
 uint64_t ReadUleb128(const char* addr, uint64_t* ret);
 bool ReadUleb128(raw_istream& is, uint64_t* ret);
 

--- a/src/main/native/include/support/raw_istream.h
+++ b/src/main/native/include/support/raw_istream.h
@@ -56,7 +56,7 @@ class raw_istream {
   // @param buf Buffer for output
   // @param maxLen Maximum length
   // @return Line
-  llvm::StringRef getline(llvm::SmallVectorImpl<char>& buf, int maxLen);
+  wpi_llvm::StringRef getline(wpi_llvm::SmallVectorImpl<char>& buf, int maxLen);
 
   virtual void close() = 0;
   virtual size_t in_avail() const = 0;
@@ -78,7 +78,7 @@ class raw_istream {
 
 class raw_mem_istream : public raw_istream {
  public:
-  explicit raw_mem_istream(llvm::StringRef mem);
+  explicit raw_mem_istream(wpi_llvm::StringRef mem);
   raw_mem_istream(const char* mem, size_t len) : m_cur(mem), m_left(len) {}
   void close() override;
   size_t in_avail() const override;
@@ -92,7 +92,7 @@ class raw_mem_istream : public raw_istream {
 
 class raw_fd_istream : public raw_istream {
  public:
-  raw_fd_istream(const llvm::Twine& filename, std::error_code& ec,
+  raw_fd_istream(const wpi_llvm::Twine& filename, std::error_code& ec,
                  size_t bufSize = 4096);
   raw_fd_istream(int fd, bool shouldClose, size_t bufSize = 4096);
   ~raw_fd_istream() override;

--- a/src/main/native/include/support/raw_socket_ostream.h
+++ b/src/main/native/include/support/raw_socket_ostream.h
@@ -14,7 +14,7 @@ namespace wpi {
 
 class NetworkStream;
 
-class raw_socket_ostream : public llvm::raw_ostream {
+class raw_socket_ostream : public wpi_llvm::raw_ostream {
  public:
   raw_socket_ostream(NetworkStream& stream, bool shouldClose)
       : m_stream(stream), m_shouldClose(shouldClose) {}

--- a/src/main/native/include/support/sha1.h
+++ b/src/main/native/include/support/sha1.h
@@ -26,10 +26,10 @@
 
 #include "llvm/StringRef.h"
 
-namespace llvm {
+namespace wpi_llvm {
 template <typename T>
 class SmallVectorImpl;
-}  // namespace llvm
+}  // namespace wpi_llvm
 
 namespace wpi {
 
@@ -38,11 +38,11 @@ class raw_istream;
 class SHA1 {
  public:
   SHA1();
-  void Update(llvm::StringRef s);
+  void Update(wpi_llvm::StringRef s);
   void Update(raw_istream& is);
   std::string Final();
-  llvm::StringRef Final(llvm::SmallVectorImpl<char>& buf);
-  static std::string FromFile(llvm::StringRef filename);
+  wpi_llvm::StringRef Final(wpi_llvm::SmallVectorImpl<char>& buf);
+  static std::string FromFile(wpi_llvm::StringRef filename);
 
  private:
   uint32_t digest[5];

--- a/src/main/native/include/tcpsockets/NetworkStream.h
+++ b/src/main/native/include/tcpsockets/NetworkStream.h
@@ -31,7 +31,7 @@ class NetworkStream {
                          int timeout = 0) = 0;
   virtual void close() = 0;
 
-  virtual llvm::StringRef getPeerIP() const = 0;
+  virtual wpi_llvm::StringRef getPeerIP() const = 0;
   virtual int getPeerPort() const = 0;
   virtual void setNoDelay() = 0;
 

--- a/src/main/native/include/tcpsockets/TCPConnector.h
+++ b/src/main/native/include/tcpsockets/TCPConnector.h
@@ -40,7 +40,7 @@ class TCPConnector {
                                                 Logger& logger,
                                                 int timeout = 0);
   static std::unique_ptr<NetworkStream> connect_parallel(
-      llvm::ArrayRef<std::pair<const char*, int>> servers, Logger& logger,
+      wpi_llvm::ArrayRef<std::pair<const char*, int>> servers, Logger& logger,
       int timeout = 0);
 };
 

--- a/src/main/native/include/tcpsockets/TCPStream.h
+++ b/src/main/native/include/tcpsockets/TCPStream.h
@@ -50,7 +50,7 @@ class TCPStream : public NetworkStream {
                  int timeout = 0) override;
   void close() override;
 
-  llvm::StringRef getPeerIP() const override;
+  wpi_llvm::StringRef getPeerIP() const override;
   int getPeerPort() const override;
   void setNoDelay() override;
   bool setBlocking(bool enabled) override;

--- a/src/main/native/include/udpsockets/UDPClient.h
+++ b/src/main/native/include/udpsockets/UDPClient.h
@@ -25,7 +25,7 @@ class UDPClient {
 
  public:
   explicit UDPClient(Logger& logger);
-  UDPClient(llvm::StringRef address, Logger& logger);
+  UDPClient(wpi_llvm::StringRef address, Logger& logger);
   UDPClient(const UDPClient& other) = delete;
   UDPClient(UDPClient&& other);
   ~UDPClient();
@@ -36,8 +36,8 @@ class UDPClient {
   int start();
   void shutdown();
   // The passed in address MUST be a resolved IP address.
-  int send(llvm::ArrayRef<uint8_t> data, llvm::StringRef server, int port);
-  int send(llvm::StringRef data, llvm::StringRef server, int port);
+  int send(wpi_llvm::ArrayRef<uint8_t> data, wpi_llvm::StringRef server, int port);
+  int send(wpi_llvm::StringRef data, wpi_llvm::StringRef server, int port);
 };
 
 }  // namespace wpi

--- a/src/test/native/cpp/Base64Test.cpp
+++ b/src/test/native/cpp/Base64Test.cpp
@@ -26,11 +26,11 @@ std::ostream& operator<<(std::ostream& os, const Base64TestParam& param) {
 
 class Base64Test : public ::testing::TestWithParam<Base64TestParam> {
  protected:
-  llvm::StringRef GetPlain() {
+  wpi_llvm::StringRef GetPlain() {
     if (GetParam().plain_len < 0)
-      return llvm::StringRef(GetParam().plain);
+      return wpi_llvm::StringRef(GetParam().plain);
     else
-      return llvm::StringRef(GetParam().plain, GetParam().plain_len);
+      return wpi_llvm::StringRef(GetParam().plain, GetParam().plain_len);
   }
 };
 
@@ -45,7 +45,7 @@ TEST_P(Base64Test, EncodeStdString) {
 }
 
 TEST_P(Base64Test, EncodeSmallString) {
-  llvm::SmallString<128> buf;
+  wpi_llvm::SmallString<128> buf;
   ASSERT_EQ(GetParam().encoded, Base64Encode(GetPlain(), buf));
   // reuse buf
   ASSERT_EQ(GetParam().encoded, Base64Encode(GetPlain(), buf));
@@ -53,7 +53,7 @@ TEST_P(Base64Test, EncodeSmallString) {
 
 TEST_P(Base64Test, DecodeStdString) {
   std::string s;
-  llvm::StringRef encoded = GetParam().encoded;
+  wpi_llvm::StringRef encoded = GetParam().encoded;
   EXPECT_EQ(encoded.size(), Base64Decode(encoded, &s));
   ASSERT_EQ(GetPlain(), s);
 
@@ -63,10 +63,10 @@ TEST_P(Base64Test, DecodeStdString) {
 }
 
 TEST_P(Base64Test, DecodeSmallString) {
-  llvm::SmallString<128> buf;
-  llvm::StringRef encoded = GetParam().encoded;
+  wpi_llvm::SmallString<128> buf;
+  wpi_llvm::StringRef encoded = GetParam().encoded;
   size_t len;
-  llvm::StringRef plain = Base64Decode(encoded, &len, buf);
+  wpi_llvm::StringRef plain = Base64Decode(encoded, &len, buf);
   EXPECT_EQ(encoded.size(), len);
   ASSERT_EQ(GetPlain(), plain);
 

--- a/src/test/native/cpp/hostname.cpp
+++ b/src/test/native/cpp/hostname.cpp
@@ -14,7 +14,7 @@
 namespace wpi {
 TEST(HostNameTest, HostNameNotEmpty) { ASSERT_NE(wpi::GetHostname(), ""); }
 TEST(HostNameTest, HostNameNotEmptySmallVector) {
-  llvm::SmallVector<char, 256> name;
+  wpi_llvm::SmallVector<char, 256> name;
   ASSERT_NE(wpi::GetHostname(name), "");
 }
 }  // namespace wpi

--- a/src/test/native/cpp/json/unit-cbor.cpp
+++ b/src/test/native/cpp/json/unit-cbor.cpp
@@ -735,7 +735,7 @@ TEST(CborFloatTest, Number)
 
 TEST(CborFloatTest, HalfInfinity)
 {
-    json j = json::from_cbor(llvm::StringRef("\xf9\x7c\x00", 3));
+    json j = json::from_cbor(wpi_llvm::StringRef("\xf9\x7c\x00", 3));
     json::number_float_t d = j;
     EXPECT_FALSE(std::isfinite(d));
     EXPECT_EQ(j.dump(), "null");
@@ -1138,31 +1138,31 @@ TEST(CborErrorTest, TooShortByteVector)
                      "[json.exception.parse_error.110] parse error at 2: unexpected end of input");
     EXPECT_THROW_MSG(json::from_cbor("\x19"), json::parse_error,
                      "[json.exception.parse_error.110] parse error at 2: unexpected end of input");
-    EXPECT_THROW_MSG(json::from_cbor(llvm::StringRef("\x19\x00", 2)), json::parse_error,
+    EXPECT_THROW_MSG(json::from_cbor(wpi_llvm::StringRef("\x19\x00", 2)), json::parse_error,
                      "[json.exception.parse_error.110] parse error at 3: unexpected end of input");
     EXPECT_THROW_MSG(json::from_cbor("\x1a"), json::parse_error,
                      "[json.exception.parse_error.110] parse error at 2: unexpected end of input");
-    EXPECT_THROW_MSG(json::from_cbor(llvm::StringRef("\x1a\x00", 2)), json::parse_error,
+    EXPECT_THROW_MSG(json::from_cbor(wpi_llvm::StringRef("\x1a\x00", 2)), json::parse_error,
                      "[json.exception.parse_error.110] parse error at 3: unexpected end of input");
-    EXPECT_THROW_MSG(json::from_cbor(llvm::StringRef("\x1a\x00\x00", 3)), json::parse_error,
+    EXPECT_THROW_MSG(json::from_cbor(wpi_llvm::StringRef("\x1a\x00\x00", 3)), json::parse_error,
                      "[json.exception.parse_error.110] parse error at 4: unexpected end of input");
-    EXPECT_THROW_MSG(json::from_cbor(llvm::StringRef("\x1a\x00\x00\x00", 4)), json::parse_error,
+    EXPECT_THROW_MSG(json::from_cbor(wpi_llvm::StringRef("\x1a\x00\x00\x00", 4)), json::parse_error,
                      "[json.exception.parse_error.110] parse error at 5: unexpected end of input");
     EXPECT_THROW_MSG(json::from_cbor("\x1b"), json::parse_error,
                      "[json.exception.parse_error.110] parse error at 2: unexpected end of input");
-    EXPECT_THROW_MSG(json::from_cbor(llvm::StringRef("\x1b\x00", 2)), json::parse_error,
+    EXPECT_THROW_MSG(json::from_cbor(wpi_llvm::StringRef("\x1b\x00", 2)), json::parse_error,
                      "[json.exception.parse_error.110] parse error at 3: unexpected end of input");
-    EXPECT_THROW_MSG(json::from_cbor(llvm::StringRef("\x1b\x00\x00", 3)), json::parse_error,
+    EXPECT_THROW_MSG(json::from_cbor(wpi_llvm::StringRef("\x1b\x00\x00", 3)), json::parse_error,
                      "[json.exception.parse_error.110] parse error at 4: unexpected end of input");
-    EXPECT_THROW_MSG(json::from_cbor(llvm::StringRef("\x1b\x00\x00\x00", 4)), json::parse_error,
+    EXPECT_THROW_MSG(json::from_cbor(wpi_llvm::StringRef("\x1b\x00\x00\x00", 4)), json::parse_error,
                      "[json.exception.parse_error.110] parse error at 5: unexpected end of input");
-    EXPECT_THROW_MSG(json::from_cbor(llvm::StringRef("\x1b\x00\x00\x00\x00", 5)), json::parse_error,
+    EXPECT_THROW_MSG(json::from_cbor(wpi_llvm::StringRef("\x1b\x00\x00\x00\x00", 5)), json::parse_error,
                      "[json.exception.parse_error.110] parse error at 6: unexpected end of input");
-    EXPECT_THROW_MSG(json::from_cbor(llvm::StringRef("\x1b\x00\x00\x00\x00\x00", 6)), json::parse_error,
+    EXPECT_THROW_MSG(json::from_cbor(wpi_llvm::StringRef("\x1b\x00\x00\x00\x00\x00", 6)), json::parse_error,
                      "[json.exception.parse_error.110] parse error at 7: unexpected end of input");
-    EXPECT_THROW_MSG(json::from_cbor(llvm::StringRef("\x1b\x00\x00\x00\x00\x00\x00", 7)), json::parse_error,
+    EXPECT_THROW_MSG(json::from_cbor(wpi_llvm::StringRef("\x1b\x00\x00\x00\x00\x00\x00", 7)), json::parse_error,
                      "[json.exception.parse_error.110] parse error at 8: unexpected end of input");
-    EXPECT_THROW_MSG(json::from_cbor(llvm::StringRef("\x1b\x00\x00\x00\x00\x00\x00\x00", 8)), json::parse_error,
+    EXPECT_THROW_MSG(json::from_cbor(wpi_llvm::StringRef("\x1b\x00\x00\x00\x00\x00\x00\x00", 8)), json::parse_error,
                      "[json.exception.parse_error.110] parse error at 9: unexpected end of input");
 }
 
@@ -1547,7 +1547,7 @@ TEST(CborFirstBytesTest, Unsupported)
 
         try
         {
-            json::from_cbor(llvm::StringRef(&byte, 1));
+            json::from_cbor(wpi_llvm::StringRef(&byte, 1));
         }
         catch (const json::parse_error& e)
         {
@@ -1571,7 +1571,7 @@ TEST(CborFirstBytesTest, Unsupported)
 namespace {
 struct CborRoundtripTestParam {
   const char* plain;
-  llvm::StringRef encoded;
+  wpi_llvm::StringRef encoded;
   bool test_encode;
 };
 }  // anonymous namespace
@@ -1589,7 +1589,7 @@ TEST_P(CborRoundtripTest, Case)
 }
 
 static const CborRoundtripTestParam rfc7049_appendix_a_numbers[] = {
-    {"0", llvm::StringRef("\x00", 1), true},
+    {"0", wpi_llvm::StringRef("\x00", 1), true},
     {"1", "\x01", true},
     {"10", "\x0a", true},
     {"23", "\x17", true},
@@ -1597,38 +1597,38 @@ static const CborRoundtripTestParam rfc7049_appendix_a_numbers[] = {
     {"25", "\x18\x19", true},
     {"100", "\x18\x64", true},
     {"1000", "\x19\x03\xe8", true},
-    {"1000000", llvm::StringRef("\x1a\x00\x0f\x42\x40", 5), true},
-    {"1000000000000", llvm::StringRef("\x1b\x00\x00\x00\xe8\xd4\xa5\x10\x00", 9), true},
+    {"1000000", wpi_llvm::StringRef("\x1a\x00\x0f\x42\x40", 5), true},
+    {"1000000000000", wpi_llvm::StringRef("\x1b\x00\x00\x00\xe8\xd4\xa5\x10\x00", 9), true},
     {"18446744073709551615", "\x1b\xff\xff\xff\xff\xff\xff\xff\xff", true},
     // positive bignum is not supported
-    //{"18446744073709551616", llvm::StringRef("\xc2\x49\x01\x00\x00\x00\x00\x00\x00\x00\x00", 11), true},
+    //{"18446744073709551616", wpi_llvm::StringRef("\xc2\x49\x01\x00\x00\x00\x00\x00\x00\x00\x00", 11), true},
     //{"-18446744073709551616", "\x3b\xff\xff\xff\xff\xff\xff\xff\xff", true},
     // negative bignum is not supported
-    //{"-18446744073709551617", llvm::StringRef("\xc3\x49\x01\x00\x00\x00\x00\x00\x00\x00\x00", 11), true},
+    //{"-18446744073709551617", wpi_llvm::StringRef("\xc3\x49\x01\x00\x00\x00\x00\x00\x00\x00\x00", 11), true},
     {"-1", "\x20", true},
     {"-10", "\x29", true},
     {"-100", "\x38\x63", true},
     {"-1000", "\x39\x03\xe7", true},
     // half-precision float
-    {"0.0", llvm::StringRef("\xf9\x00\x00", 3), false},
+    {"0.0", wpi_llvm::StringRef("\xf9\x00\x00", 3), false},
     // half-precision float
-    {"-0.0", llvm::StringRef("\xf9\x80\x00", 3), false},
+    {"-0.0", wpi_llvm::StringRef("\xf9\x80\x00", 3), false},
     // half-precision float
-    {"1.0", llvm::StringRef("\xf9\x3c\x00", 3), false},
+    {"1.0", wpi_llvm::StringRef("\xf9\x3c\x00", 3), false},
     {"1.1", "\xfb\x3f\xf1\x99\x99\x99\x99\x99\x9a", true},
     // half-precision float
-    {"1.5", llvm::StringRef("\xf9\x3e\x00", 3), false},
+    {"1.5", wpi_llvm::StringRef("\xf9\x3e\x00", 3), false},
     // half-precision float
     {"65504.0", "\xf9\x7b\xff", false},
-    {"100000.0", llvm::StringRef("\xfa\x47\xc3\x50\x00", 5), false},
+    {"100000.0", wpi_llvm::StringRef("\xfa\x47\xc3\x50\x00", 5), false},
     {"3.4028234663852886e+38", "\xfa\x7f\x7f\xff\xff", false},
-    {"1.0e+300", llvm::StringRef("\xfb\x7e\x37\xe4\x3c\x88\x00\x75\x9c", 9), true},
+    {"1.0e+300", wpi_llvm::StringRef("\xfb\x7e\x37\xe4\x3c\x88\x00\x75\x9c", 9), true},
     // half-precision float
-    {"5.960464477539063e-8", llvm::StringRef("\xf9\x00\x01", 3), false},
+    {"5.960464477539063e-8", wpi_llvm::StringRef("\xf9\x00\x01", 3), false},
     // half-precision float
-    {"0.00006103515625", llvm::StringRef("\xf9\x04\x00", 3), false},
+    {"0.00006103515625", wpi_llvm::StringRef("\xf9\x04\x00", 3), false},
     // half-precision float
-    {"-4.0", llvm::StringRef("\xf9\xc4\x00", 3), false},
+    {"-4.0", wpi_llvm::StringRef("\xf9\xc4\x00", 3), false},
     {"-4.1", "\xfb\xc0\x10\x66\x66\x66\x66\x66\x66", true},
 };
 

--- a/src/test/native/cpp/json/unit-convenience.cpp
+++ b/src/test/native/cpp/json/unit-convenience.cpp
@@ -68,11 +68,11 @@ class JsonStringEscapeTest
     : public ::testing::TestWithParam<std::pair<const char*, const char*>> {};
 TEST_P(JsonStringEscapeTest, Case)
 {
-    llvm::SmallString<32> buf;
-    llvm::raw_svector_ostream ss(buf);
+    wpi_llvm::SmallString<32> buf;
+    wpi_llvm::raw_svector_ostream ss(buf);
     json::serializer s(ss);
     s.dump_escaped(GetParam().first);
-    EXPECT_EQ(ss.str(), llvm::StringRef(GetParam().second));
+    EXPECT_EQ(ss.str(), wpi_llvm::StringRef(GetParam().second));
 }
 
 static const std::pair<const char*, const char*> string_escape_cases[] = {

--- a/src/test/native/cpp/json/unit-msgpack.cpp
+++ b/src/test/native/cpp/json/unit-msgpack.cpp
@@ -1008,31 +1008,31 @@ TEST(MessagePackErrorTest, TooShortByteVector)
                      "[json.exception.parse_error.110] parse error at 2: unexpected end of input");
     EXPECT_THROW_MSG(json::from_msgpack("\xcd"), json::parse_error,
                      "[json.exception.parse_error.110] parse error at 2: unexpected end of input");
-    EXPECT_THROW_MSG(json::from_msgpack(llvm::StringRef("\xcd\x00", 2)), json::parse_error,
+    EXPECT_THROW_MSG(json::from_msgpack(wpi_llvm::StringRef("\xcd\x00", 2)), json::parse_error,
                      "[json.exception.parse_error.110] parse error at 3: unexpected end of input");
     EXPECT_THROW_MSG(json::from_msgpack("\xce"), json::parse_error,
                      "[json.exception.parse_error.110] parse error at 2: unexpected end of input");
-    EXPECT_THROW_MSG(json::from_msgpack(llvm::StringRef("\xce\x00", 2)), json::parse_error,
+    EXPECT_THROW_MSG(json::from_msgpack(wpi_llvm::StringRef("\xce\x00", 2)), json::parse_error,
                      "[json.exception.parse_error.110] parse error at 3: unexpected end of input");
-    EXPECT_THROW_MSG(json::from_msgpack(llvm::StringRef("\xce\x00\x00", 3)), json::parse_error,
+    EXPECT_THROW_MSG(json::from_msgpack(wpi_llvm::StringRef("\xce\x00\x00", 3)), json::parse_error,
                      "[json.exception.parse_error.110] parse error at 4: unexpected end of input");
-    EXPECT_THROW_MSG(json::from_msgpack(llvm::StringRef("\xce\x00\x00\x00", 4)), json::parse_error,
+    EXPECT_THROW_MSG(json::from_msgpack(wpi_llvm::StringRef("\xce\x00\x00\x00", 4)), json::parse_error,
                      "[json.exception.parse_error.110] parse error at 5: unexpected end of input");
     EXPECT_THROW_MSG(json::from_msgpack("\xcf"), json::parse_error,
                      "[json.exception.parse_error.110] parse error at 2: unexpected end of input");
-    EXPECT_THROW_MSG(json::from_msgpack(llvm::StringRef("\xcf\x00", 2)), json::parse_error,
+    EXPECT_THROW_MSG(json::from_msgpack(wpi_llvm::StringRef("\xcf\x00", 2)), json::parse_error,
                      "[json.exception.parse_error.110] parse error at 3: unexpected end of input");
-    EXPECT_THROW_MSG(json::from_msgpack(llvm::StringRef("\xcf\x00\x00", 3)), json::parse_error,
+    EXPECT_THROW_MSG(json::from_msgpack(wpi_llvm::StringRef("\xcf\x00\x00", 3)), json::parse_error,
                      "[json.exception.parse_error.110] parse error at 4: unexpected end of input");
-    EXPECT_THROW_MSG(json::from_msgpack(llvm::StringRef("\xcf\x00\x00\x00", 4)), json::parse_error,
+    EXPECT_THROW_MSG(json::from_msgpack(wpi_llvm::StringRef("\xcf\x00\x00\x00", 4)), json::parse_error,
                      "[json.exception.parse_error.110] parse error at 5: unexpected end of input");
-    EXPECT_THROW_MSG(json::from_msgpack(llvm::StringRef("\xcf\x00\x00\x00\x00", 5)), json::parse_error,
+    EXPECT_THROW_MSG(json::from_msgpack(wpi_llvm::StringRef("\xcf\x00\x00\x00\x00", 5)), json::parse_error,
                      "[json.exception.parse_error.110] parse error at 6: unexpected end of input");
-    EXPECT_THROW_MSG(json::from_msgpack(llvm::StringRef("\xcf\x00\x00\x00\x00\x00", 6)), json::parse_error,
+    EXPECT_THROW_MSG(json::from_msgpack(wpi_llvm::StringRef("\xcf\x00\x00\x00\x00\x00", 6)), json::parse_error,
                      "[json.exception.parse_error.110] parse error at 7: unexpected end of input");
-    EXPECT_THROW_MSG(json::from_msgpack(llvm::StringRef("\xcf\x00\x00\x00\x00\x00\x00", 7)), json::parse_error,
+    EXPECT_THROW_MSG(json::from_msgpack(wpi_llvm::StringRef("\xcf\x00\x00\x00\x00\x00\x00", 7)), json::parse_error,
                      "[json.exception.parse_error.110] parse error at 8: unexpected end of input");
-    EXPECT_THROW_MSG(json::from_msgpack(llvm::StringRef("\xcf\x00\x00\x00\x00\x00\x00\x00", 8)), json::parse_error,
+    EXPECT_THROW_MSG(json::from_msgpack(wpi_llvm::StringRef("\xcf\x00\x00\x00\x00\x00\x00\x00", 8)), json::parse_error,
                      "[json.exception.parse_error.110] parse error at 9: unexpected end of input");
 }
 

--- a/src/test/native/cpp/json/unit-readme.cpp
+++ b/src/test/native/cpp/json/unit-readme.cpp
@@ -124,14 +124,14 @@ TEST(JsonReadmeTest, FromToString)
 
     // explicit conversion to string
     std::string s;
-    llvm::raw_string_ostream os(s);
+    wpi_llvm::raw_string_ostream os(s);
     j.dump(os);    // {\"happy\":true,\"pi\":3.141}
     EXPECT_EQ(os.str(), "{\"happy\":true,\"pi\":3.141}");
 
     // serialization with pretty printing
     // pass in the amount of spaces to indent
     std::string s2;
-    llvm::raw_string_ostream os2(s2);
+    wpi_llvm::raw_string_ostream os2(s2);
     j2.dump(os2, 4);
     EXPECT_EQ(os2.str(), "{\n    \"happy\": true,\n    \"pi\": 3.141\n}");
     // {
@@ -149,7 +149,7 @@ TEST(JsonReadmeTest, Basic2)
     j.push_back(true);
 
     std::string s;
-    llvm::raw_string_ostream os(s);
+    wpi_llvm::raw_string_ostream os(s);
 
     // iterate the array
     for (json::iterator it = j.begin(); it != j.end(); ++it)
@@ -198,7 +198,7 @@ TEST(JsonReadmeTest, OtherContainer)
 {
     std::vector<int> c_vector {1, 2, 3, 4};
     json j_vec(c_vector);
-    json j_vec2(llvm::makeArrayRef(c_vector));
+    json j_vec2(wpi_llvm::makeArrayRef(c_vector));
     // [1, 2, 3, 4]
 
     std::deque<float> c_deque {1.2f, 2.3f, 3.4f, 5.6f};

--- a/src/test/native/cpp/json/unit-unicode.cpp
+++ b/src/test/native/cpp/json/unit-unicode.cpp
@@ -90,18 +90,18 @@ using wpi::json;
 
 error:
     auto result = ::testing::AssertionFailure();
-    result << basemsg << " with {" << llvm::utohexstr(byte1);
+    result << basemsg << " with {" << wpi_llvm::utohexstr(byte1);
     if (byte2 != -1)
     {
-        result << ',' << llvm::utohexstr(byte2);
+        result << ',' << wpi_llvm::utohexstr(byte2);
     }
     if (byte3 != -1)
     {
-        result << ',' << llvm::utohexstr(byte3);
+        result << ',' << wpi_llvm::utohexstr(byte3);
     }
     if (byte4 != -1)
     {
-        result << ',' << llvm::utohexstr(byte4);
+        result << ',' << wpi_llvm::utohexstr(byte4);
     }
     result << '}';
     return result;
@@ -919,8 +919,8 @@ static std::string codepoint_to_unicode(std::size_t cp)
     // by four hexadecimal digits that encode the character's code
     // point
     std::string s;
-    llvm::raw_string_ostream ss(s);
-    ss << "\\u" << llvm::format_hex_no_prefix(cp, 4);
+    wpi_llvm::raw_string_ostream ss(s);
+    ss << "\\u" << wpi_llvm::format_hex_no_prefix(cp, 4);
     ss.flush();
     return s;
 }

--- a/src/test/native/cpp/leb128Test.cpp
+++ b/src/test/native/cpp/leb128Test.cpp
@@ -29,8 +29,8 @@ namespace wpi {
 TEST(LEB128Test, WriteUleb128) {
 #define EXPECT_ULEB128_EQ(EXPECTED, VALUE, PAD)               \
   do {                                                        \
-    llvm::StringRef expected(EXPECTED, sizeof(EXPECTED) - 1); \
-    llvm::SmallString<32> buf;                                \
+    wpi_llvm::StringRef expected(EXPECTED, sizeof(EXPECTED) - 1); \
+    wpi_llvm::SmallString<32> buf;                                \
     size_t size = WriteUleb128(buf, VALUE);                   \
     EXPECT_EQ(size, buf.size());                              \
     EXPECT_EQ(expected, buf.str());                           \


### PR DESCRIPTION
If wpiutil is loaded at the same time as a system's own implementation of libLLVM, the conflicting names can cause the wrong functions to get executed.  In Shuffleboard, this can happen if an OpenGL implementation dynamically links to libLLVM, which causes the program to segfault on startup.  See [this issue](https://github.com/wpilibsuite/shuffleboard/issues/361).