### PR TITLE
HttpRequest: Don't reorder parameters.

### DIFF
--- a/src/main/native/include/support/HttpUtil.inl
+++ b/src/main/native/include/support/HttpUtil.inl
@@ -13,11 +13,11 @@ namespace wpi {
 template <typename T>
 HttpRequest::HttpRequest(const HttpLocation& loc, const T& extraParams)
     : host{loc.host}, port{loc.port} {
-  llvm::StringMap<llvm::StringRef> params;
+  llvm::SmallVector<std::pair<llvm::StringRef, llvm::StringRef>, 8> params;
   for (const auto& p : loc.params)
-    params.insert(std::make_pair(GetFirst(p), GetSecond(p)));
+    params.emplace_back(std::make_pair(GetFirst(p), GetSecond(p)));
   for (const auto& p : extraParams)
-    params.insert(std::make_pair(GetFirst(p), GetSecond(p)));
+    params.emplace_back(std::make_pair(GetFirst(p), GetSecond(p)));
   SetPath(loc.path, params);
   SetAuth(loc);
 }


### PR DESCRIPTION
Also now allows duplicate parameters (which is needed for some use cases).